### PR TITLE
Upgrade RtMidi and fixup FFI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,13 @@ parameters:
     type: string
     default: "v1"
 
+commands:
+  install_native_deps:
+    steps:
+    - run:
+      name: Install apt
+      command: "apt-get update && apt-get install -y $(cat docker/packages.txt)"
+
 jobs:
   stack_build:
     parameters:
@@ -16,6 +23,7 @@ jobs:
     docker:
       - image: haskell:<< parameters.lts_ghc_ver >>
     steps:
+      - install_native_deps
       - checkout
       - restore_cache:
           name: Restore cached dependencies
@@ -23,7 +31,7 @@ jobs:
             - stack-<< pipeline.parameters.cache_ver >>-{{ checksum "stack.yaml" }}-{{ checksum "<< pipeline.parameters.project >>.cabal" }}
       - run:
           name: Run tests
-          command: stack test
+          command: stack test --flag RtMidi:jack
       - save_cache:
           name: Cache dependencies
           key: stack-<< pipeline.parameters.cache_ver >>-{{ checksum "stack.yaml" }}-{{ checksum "<< pipeline.parameters.project >>.cabal" }}
@@ -37,6 +45,7 @@ jobs:
     docker:
       - image: haskell:<< parameters.ghc_ver >>
     steps:
+      - install_native_deps
       - checkout
       - restore_cache:
           name: Restore cached dependencies
@@ -47,7 +56,7 @@ jobs:
           command: cabal update
       - run:
           name: Build project
-          command: cabal build
+          command: cabal build -fjack
       - run:
           name: Run tests
           command: cabal test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,8 @@ jobs:
           keys:
             - stack-<< pipeline.parameters.cache_ver >>-{{ checksum "stack.yaml" }}-{{ checksum "<< pipeline.parameters.project >>.cabal" }}
       - run:
-          name: Resolve/update dependencies
-          command: make cisetup
-      - run:
           name: Run tests
-          command: make citest
+          command: stack test
       - save_cache:
           name: Cache dependencies
           key: stack-<< pipeline.parameters.cache_ver >>-{{ checksum "stack.yaml" }}-{{ checksum "<< pipeline.parameters.project >>.cabal" }}

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,41 @@
+steps:
+  - simple_align:
+      cases: false
+      top_level_patterns: false
+      records: false
+
+  - imports:
+      align: none
+      list_align: after_alias
+      pad_module_names: false
+      long_list_align: inline
+      empty_list_align: inherit
+      list_padding: 4
+      separate_lists: true
+      space_surround: false
+
+  - language_pragmas:
+      style: vertical
+      align: false
+      remove_redundant: true
+
+  - tabs:
+      spaces: 2
+
+  - trailing_whitespace: {}
+
+columns: 120
+
+newline: lf
+
+language_extensions:
+  - DataKinds
+  - ExplicitForAll
+  - FlexibleContexts
+  - LambdaCase
+  - MultiParamTypeClasses
+  - MultiWayIf
+  - Rank2Types
+  - TemplateHaskell
+  - TupleSections
+  - TypeApplications

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,25 @@ update-sources:
 
 .PHONY: install-dev-deps
 install-dev-deps:
+	# Install some useful packages for development
 	stack build --copy-compiler-tool ghcid hlint stylish-haskell
 
 .PHONY: format
 format:
+	# Run stylish-haskell to format our haskell source
 	find Sound -name '*.hs' | xargs -t stack exec -- stylish-haskell -i
 
 .PHONY: lint
 lint:
+	# Run hlint over our haskell source
 	stack exec -- hlint -i 'Parse error' -i 'Reduce duplication' Sound
+
+.PHONY: docker-build
+docker-build:
+	# Build a development image for testing builds on linux
+	cd docker && docker build -t haskell-rtmidi-dev .
+
+.PHONY: docker-repl
+docker-repl:
+	# Enter our development image
+	docker run -i -v $(realpath .):/project -w /project -t haskell-rtmidi-dev /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-RT_MIDI_VERSION := "4.0.0"
-RT_MIDI_URL := "https://raw.githubusercontent.com/thestk/rtmidi/$(RT_MIDI_VERSION)"
+RT_MIDI_VERSION := 4.0.0
+RT_MIDI_URL := https://raw.githubusercontent.com/thestk/rtmidi/$(RT_MIDI_VERSION)
 
 .PHONY: update-sources
 update-sources:
@@ -8,3 +8,15 @@ update-sources:
 	curl --output rtmidi/RtMidi.h $(RT_MIDI_URL)/RtMidi.h
 	curl --output rtmidi/rtmidi_c.cpp $(RT_MIDI_URL)/rtmidi_c.cpp
 	curl --output rtmidi/rtmidi_c.h $(RT_MIDI_URL)/rtmidi_c.h
+
+.PHONY: install-dev-deps
+install-dev-deps:
+	stack build --copy-compiler-tool ghcid hlint stylish-haskell
+
+.PHONY: format
+format:
+	find Sound -name '*.hs' | xargs -t stack exec -- stylish-haskell -i
+
+.PHONY: lint
+lint:
+	stack exec -- hlint -i 'Parse error' -i 'Reduce duplication' Sound

--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ You can get started with development like so:
     # Verify that it works:
     stack exec -- rtmidi-query
 
+There is also a `Dockerfile` in the `docker` directory and some `make` targets that can help you verify Linux builds:
+
+    # Build the image and tag it `haskell-rtmidi-dev`
+    make docker-build
+
+    # Enter the docker image
+    make docker-repl
+
+    # Inside the docker image:
+    cabal update && cabal build -fjack
+
+(Note that you can't use any `RtMidi` functions in the containerized env unless you are running a Linux host, and
+even then you'd probably have to start the process with something like `docker run --device /dev/snd`.)
+
 ## TODO
 
 * Add Windows MM support. This should only require a few changes to the Cabal file.

--- a/RtMidi.cabal
+++ b/RtMidi.cabal
@@ -1,6 +1,6 @@
 name:                RtMidi
 version:             0.2.0.0
-synopsis:            Wrapper for RtMidi, the lightweight, cross-platform MIDI I/O library
+synopsis:            Haskell wrapper for RtMidi, the lightweight, cross-platform MIDI I/O library.
 description:         Please see the README on GitHub at <https://github.com/riottracker/RtMidi#readme>
 category:            Sound
 build-type:          Simple

--- a/RtMidi.cabal
+++ b/RtMidi.cabal
@@ -1,13 +1,15 @@
 name:                RtMidi
 version:             0.2.0.0
-description:         Haskell wrapper for RtMidi, the lightweight, cross-platform MIDI I/O library.
+synopsis:            Wrapper for RtMidi, the lightweight, cross-platform MIDI I/O library
+description:         Please see the README on GitHub at <https://github.com/riottracker/RtMidi#readme>
 category:            Sound
 build-type:          Simple
-author:              kohlrabi
+author:              kohlrabi, Eric Conlon
 license-file:        LICENSE
 homepage:            https://github.com/riottracker/RtMidi
-maintainer:          kohlrabi@kohlra.biz
-extra-source-files:  rtmidi/rtmidi_c.h
+maintainer:          ejconlon@gmail.com
+extra-source-files:  README.md
+                     rtmidi/rtmidi_c.h
                      rtmidi/RtMidi.h
                      examples/callback.hs
                      examples/playback.hs

--- a/RtMidi.cabal
+++ b/RtMidi.cabal
@@ -56,6 +56,12 @@ library
   if flag(core) && os(darwin)
     cc-options:       -D__MACOSX_CORE__
     frameworks:       CoreMIDI CoreAudio CoreFoundation
+    -- NOTE(ejconlon) This is to make the c ffi wrapper actually catch
+    -- the c++ exceptions instead of simply aborting.
+    -- Cribbed from https://github.com/fpco/inline-c/pull/89
+    -- avoid https://gitlab.haskell.org/ghc/ghc/issues/11829
+    ld-options:        -Wl,-keep_dwarf_unwind
+    ghc-options:       -pgmc=clang++
   -- TODO(ejconlon) Add windows support
 
 executable rtmidi-callback
@@ -65,6 +71,7 @@ executable rtmidi-callback
       base
     , RtMidi
   default-language:   Haskell2010
+  ghc-options: -threaded -rtsopts
 
 executable rtmidi-playback
   main-is:            playback.hs
@@ -73,6 +80,7 @@ executable rtmidi-playback
       base
     , RtMidi
   default-language:   Haskell2010
+  ghc-options: -threaded -rtsopts
 
 executable rtmidi-poll
   main-is:            poll.hs
@@ -81,6 +89,7 @@ executable rtmidi-poll
       base
     , RtMidi
   default-language:   Haskell2010
+  ghc-options: -threaded -rtsopts
 
 executable rtmidi-query
   main-is:            query.hs
@@ -89,6 +98,7 @@ executable rtmidi-query
       base
     , RtMidi
   default-language:   Haskell2010
+  ghc-options: -threaded -rtsopts
 
 source-repository head
   type:     git

--- a/RtMidi.cabal
+++ b/RtMidi.cabal
@@ -9,9 +9,10 @@ homepage:            https://github.com/riottracker/RtMidi
 maintainer:          kohlrabi@kohlra.biz
 extra-source-files:  rtmidi/rtmidi_c.h
                      rtmidi/RtMidi.h
-                     examples/playback.hs
-                     examples/query.hs
                      examples/callback.hs
+                     examples/playback.hs
+                     examples/poll.hs
+                     examples/query.hs
 cabal-version:       >=1.10
 license:             MIT
 
@@ -39,6 +40,7 @@ Flag core {
 
 library
   exposed-modules:     Sound.RtMidi
+  other-modules:       Sound.RtMidi.Foreign
   build-depends:       base >=4.9 && <4.15
   default-language:    Haskell2010
   include-dirs:        rtmidi

--- a/Sound/RtMidi.hs
+++ b/Sound/RtMidi.hs
@@ -1,53 +1,72 @@
-{-# LANGUAGE ForeignFunctionInterface #-}
-
-
 -- | Interface to RtMidi
-module Sound.RtMidi (
-      Device
-    , Error (..)
-    , ErrorType (..)
-    , Api(..)
-    , ready
-    , reportError
---    , checkForErrors
-    , compiledApis
-    , openPort
-    , openVirtualPort
-    , closePort
-    , portCount
-    , portName
-    , defaultInput
-    , createInput
-    , setCallback
-    , setCallbackWithUserData
-    , cancelCallback
-    , ignoreTypes
-    , getMessage
-    , defaultOutput
-    , createOutput
-    , sendMessage
-    , closeInput
-    , closeOutput
-    , currentApi
-    ) where
+module Sound.RtMidi
+  ( InputDevice
+  , OutputDevice
+  , IsDevice (getDeviceType)
+  , DeviceType (..)
+  , Api (..)
+  , Error (..)
+  , ready
+  , compiledApis
+  , openPort
+  , openVirtualPort
+  , closePort
+  , portCount
+  , portName
+  , defaultInput
+  , createInput
+  , setCallback
+  , setCallbackWithUserData
+  , cancelCallback
+  , ignoreTypes
+  , getMessage
+  , defaultOutput
+  , createOutput
+  , sendMessage
+  , closeDevice
+  , currentApi
+  ) where
 
-import Control.Monad
-import Foreign
-import Foreign.C
-import Foreign.C.String
+import Control.Exception (Exception, throwIO)
+import Control.Monad (unless)
+import Data.Coerce (coerce)
+import Data.Word (Word8)
+import Foreign (FunPtr, Ptr, Storable (..), alloca, allocaArray, allocaBytes, nullPtr, peekArray, with, withArrayLen)
+import Foreign.C (CDouble (..), CInt (..), CSize, CString, CUChar (..), peekCString, withCString)
+import Sound.RtMidi.Foreign
 
+-- This just needs to be bigger than the max MIDI message size, which is 3 bytes
+maxMessageSize :: Int
+maxMessageSize = 4
 
-data Device = Input (Ptr Wrapper) | Output (Ptr Wrapper)
+data DeviceType =
+    InputDeviceType
+  | OutputDeviceType
+  deriving (Eq, Show)
 
-device :: Device -> Ptr Wrapper
-device (Input x) = x
-device (Output x) = x
+newtype Device = Device { unDevice :: Ptr Wrapper }
+  deriving (Eq, Show)
 
-toInput :: Device -> Ptr Wrapper
-toInput (Input x) = x
+class IsDevice d where
+  toDevice :: d -> Device
+  getDeviceType :: d -> DeviceType
 
-toOutput :: Device -> Ptr Wrapper
-toOutput (Output x) = x
+toDevicePtr :: IsDevice d => d -> Ptr Wrapper
+toDevicePtr = unDevice . toDevice
+
+newtype InputDevice = InputDevice { unInputDevice :: Device }
+  deriving (Eq, Show)
+
+instance IsDevice InputDevice where
+  toDevice = unInputDevice
+  getDeviceType _ = InputDeviceType
+
+newtype OutputDevice = OutputDevice { unOutputDevice :: Device }
+  deriving (Eq, Show)
+
+instance IsDevice OutputDevice where
+  toDevice = unOutputDevice
+  getDeviceType _ = OutputDeviceType
 
 data Api
   = UnspecifiedApi
@@ -73,279 +92,204 @@ instance Enum Api where
   toEnum 4 = MultimediaApi
   toEnum 5 = DummyApi
 
-data ErrorType
-  = Warning
-  | DebugWarning
-  | UnspecifiedError
-  | NoDevicesFound
-  | InvalidDevice
-  | MemoryError
-  | InvalidParameter
-  | InvalidUse
-  | DriverError
-  | SystemError
-  | ThreadError
-  deriving (Eq, Show)
-
-instance Enum ErrorType where
-  fromEnum Warning = 0
-  fromEnum DebugWarning = 1
-  fromEnum UnspecifiedError = 2
-  fromEnum NoDevicesFound = 3
-  fromEnum InvalidDevice = 4
-  fromEnum MemoryError = 5
-  fromEnum InvalidParameter = 6
-  fromEnum InvalidUse = 7
-  fromEnum DriverError = 8
-  fromEnum SystemError = 9
-  fromEnum ThreadError = 10
-  toEnum 0 = Warning
-  toEnum 1 = DebugWarning
-  toEnum 2 = UnspecifiedError
-  toEnum 3 = NoDevicesFound
-  toEnum 4 = InvalidDevice
-  toEnum 5 = MemoryError
-  toEnum 6 = InvalidParameter
-  toEnum 7 = InvalidUse
-  toEnum 8 = DriverError
-  toEnum 9 = SystemError
-  toEnum 10 = ThreadError
-
-
-data Error = Error ErrorType String
-
-data Wrapper = Wrapper
-             { ptr :: Ptr ()
-             , ok  :: Bool
-             , msg :: CString
-             } deriving (Show, Eq)
-
-instance Storable Wrapper where
-   sizeOf _  = 24
-   alignment = sizeOf
-   peek ptr  = do
-      a <- peekByteOff ptr 0
-      b <- peekByteOff ptr 8
-      c <- peekByteOff ptr 16
-      return $ Wrapper a b c
-
 -- | Check if a device is ok
-ready :: Device -> IO Bool
-ready d = fmap ok $ peek (device d)
+ready :: IsDevice d => d -> IO Bool
+ready = fmap ok . peek  . toDevicePtr
 
+-- | An internal RtMidi error
+newtype Error = Error String deriving (Eq, Show)
+instance Exception Error
 
-checkForErrors :: Device -> IO [Char]
-checkForErrors d = peek (device d) >>= (\w -> do
-    (putStrLn $ show w)
-    a <- peekArray0 0 $ plusPtr (castPtr (msg w)) 10
-    return a) >>= return . map castCCharToChar
+guardError :: Ptr Wrapper -> IO ()
+guardError dptr = do
+  w <- peek dptr
+  unless (ok w) $ do
+    e <- peekCString (msg w)
+    throwIO (Error e)
 
-reportError :: Device -> ErrorType -> String -> IO ()
-reportError d et em = withCString em $ rtmidi_error (device d) (toEnum . fromEnum $ et)
-
-foreign import ccall "rtmidi_c.h rtmidi_error"
-   rtmidi_error :: Ptr Wrapper -> CInt -> CString -> IO ()
- 
-foreign import ccall "rtmidi_c.h rtmidi_sizeof_rtmidi_api"
-   rtmidi_sizeof_rtmidi_api :: IO CInt
-
-
-foreign import ccall "rtmidi_c.h rtmidi_get_compiled_api"
-   rtmidi_get_compiled_api :: Ptr (Ptr CInt) -> IO CInt
-
-
-foreign import ccall "rtmidi_c.h rtmidi_open_port"
-   rtmidi_open_port :: Ptr Wrapper -> CInt -> CString -> IO ()
-
-foreign import ccall "rtmidi_c.h rtmidi_open_virtual_port"
-   rtmidi_open_virtual_port :: Ptr Wrapper -> CString -> IO ()
-
-foreign import ccall "rtmidi_c.h rtmidi_close_port"
-   rtmidi_close_port :: Ptr Wrapper -> IO ()
-
-foreign import ccall "rtmidi_c.h rtmidi_get_port_count"
-   rtmidi_get_port_count :: Ptr Wrapper -> IO CInt
-
-foreign import ccall "rtmidi_c.h rtmidi_get_port_name"
-   rtmidi_get_port_name :: Ptr Wrapper -> CInt -> IO CString
-
-
-foreign import ccall "rtmidi_c.h rtmidi_in_create_default"
-   rtmidi_in_create_default :: IO (Ptr Wrapper)
-
-foreign import ccall "rtmidi_c.h rtmidi_in_create"
-   rtmidi_in_create :: CInt -> CString -> CInt -> IO (Ptr Wrapper)
-
-foreign import ccall "rtmidi_c.h rtmidi_in_free"
-   rtmidi_in_free :: Ptr Wrapper -> IO ()
-
-foreign import ccall "rtmidi_c.h rtmidi_in_get_current_api"
-   rtmidi_in_get_current_api :: Ptr Wrapper -> IO CInt
-
-foreign import ccall "rtmidi_c.h rtmidi_in_set_callback"
-   rtmidi_in_set_callback :: Ptr Wrapper -> FunPtr (CDouble -> Ptr CUChar -> CInt -> Ptr () -> IO ()) -> Ptr () -> IO ()
-
-foreign import ccall "rtmidi_c.h rtmidi_in_cancel_callback"
-   rtmidi_in_cancel_callback :: Ptr Wrapper -> IO ()
-
-foreign import ccall "rtmidi_c.h rtmidi_in_ignore_types"
-   rtmidi_in_ignore_types :: Ptr Wrapper -> Bool -> Bool -> Bool -> IO ()
-
-foreign import ccall "rtmidi_c.h rtmidi_in_get_message"
-   rtmidi_in_get_message :: Ptr Wrapper -> Ptr (Ptr CUChar) -> Ptr CSize -> IO CDouble
-
-foreign import ccall "rtmidi_c.h rtmidi_out_create_default"
-   rtmidi_out_create_default :: IO (Ptr Wrapper)
-
-foreign import ccall "rtmidi_c.h rtmidi_out_create"
-   rtmidi_out_create :: CInt -> CString -> IO (Ptr Wrapper)
-
-foreign import ccall "rtmidi_c.h rtmidi_out_free"
-   rtmidi_out_free :: Ptr Wrapper -> IO ()
-
-foreign import ccall "rtmidi_c.h rtmidi_out_get_current_api"
-   rtmidi_out_get_current_api :: Ptr Wrapper -> IO CInt
-
-foreign import ccall "rtmidi_c.h rtmidi_out_send_message"
-   rtmidi_out_send_message :: Ptr Wrapper -> Ptr CUChar -> CInt -> IO CInt
-
-
-apiSize :: IO Int
-apiSize = fromEnum <$> rtmidi_sizeof_rtmidi_api
-
--- |A static function to determine MIDI 'Api's built in.
+-- | A static function to determine MIDI 'Api's built in.
 compiledApis :: IO [Api]
 compiledApis = fmap (map (toEnum . fromEnum)) $ do
-   n <- fromIntegral <$> rtmidi_get_compiled_api nullPtr
-   allocaArray n $ flip with $ \ptr -> do
-      rtmidi_get_compiled_api ptr
-      peekArray n =<< peek ptr
+  n <- fromIntegral <$> rtmidi_get_compiled_api nullPtr
+  allocaArray n $ flip with $ \ptr -> do
+    rtmidi_get_compiled_api ptr
+    peekArray n =<< peek ptr
 
--- -- |Report an error
--- reportError :: Error -> IO ()
--- reportError (Error e s) = withCString s $ rtmidi_error (toEnum $ fromEnum $ e)
-
--- |Open a MIDI connection
-openPort :: Device
+-- | Open a MIDI connection
+openPort :: IsDevice d
+         => d
          -> Int          -- ^ port number
          -> String       -- ^ name for the application port that is used
          -> IO ()
-openPort d n name = withCString name $ rtmidi_open_port (device d) (toEnum n)
+openPort d n name = do
+  let dptr = toDevicePtr d
+  withCString name (rtmidi_open_port dptr (toEnum n))
+  guardError dptr
 
--- |This function creates a virtual MIDI output port to which other software applications can connect.
+-- | This function creates a virtual MIDI output port to which other software applications can connect.
 --
 -- This type of functionality is currently only supported by the Macintosh OS X, Linux ALSA and JACK APIs
 -- (the function does nothing with the other APIs).
-openVirtualPort :: Device -> String -> IO ()
-openVirtualPort d name = withCString name $ rtmidi_open_virtual_port (device d)
+openVirtualPort :: IsDevice d => d -> String -> IO ()
+openVirtualPort d name = do
+  let dptr = toDevicePtr d
+  withCString name (rtmidi_open_virtual_port dptr)
+  guardError dptr
 
--- |Close an open MIDI connection (if one exists).
-closePort :: Device -> IO ()
-closePort d = rtmidi_close_port $ device d
+-- | Close an open MIDI connection (if one exists).
+closePort :: IsDevice d => d -> IO ()
+closePort d = do
+  let dptr = toDevicePtr d
+  rtmidi_close_port dptr
+  guardError dptr
 
--- |Return the number of MIDI ports available to the 'Device'.
-portCount :: Device -> IO Int
-portCount d = fromIntegral <$> (rtmidi_get_port_count $ device d)
+-- | Return the number of MIDI ports available to the 'Device'.
+portCount :: IsDevice d => d -> IO Int
+portCount d = do
+  let dptr = toDevicePtr d
+  x <- rtmidi_get_port_count dptr
+  guardError dptr
+  pure (fromIntegral x)
 
--- |Return a string identifier for the specified MIDI port number.
+-- | Return a string identifier for the specified MIDI port number.
 --
--- An empty string is returned if an invalid port specifier is provided. 
-portName :: Device -> Int -> IO String
-portName d n = peekCString =<< rtmidi_get_port_name (device d) (toEnum n)
+-- An empty string is returned if an invalid port specifier is provided.
+portName :: IsDevice d => d -> Int -> IO String
+portName d n = do
+  let dptr = toDevicePtr d
+  x <- rtmidi_get_port_name dptr (toEnum n)
+  guardError dptr
+  peekCString x
 
--- |Default constructor for a 'Device' to use for input.
-defaultInput :: IO Device
-defaultInput = Input <$> rtmidi_in_create_default
+-- | Default constructor for a 'Device' to use for input.
+defaultInput :: IO InputDevice
+defaultInput = do
+  dptr <- rtmidi_in_create_default
+  guardError dptr
+  pure (InputDevice (Device dptr))
 
--- |Create a new 'Device' to use for input.
+-- | Create a new 'Device' to use for input.
 createInput :: Api        -- ^ API to use
             -> String     -- ^ client name
             -> Int        -- ^ size of the MIDI input queue
-            -> IO Device
-createInput api clientName queueSizeLimit = Input <$>
-   (withCString clientName $ \str -> rtmidi_in_create (toEnum $ fromEnum api) str (toEnum queueSizeLimit))
+            -> IO InputDevice
+createInput api clientName queueSizeLimit = do
+  dptr <- withCString clientName (\str -> rtmidi_in_create (toEnum $ fromEnum api) str (toEnum queueSizeLimit))
+  guardError dptr
+  pure (InputDevice (Device dptr))
 
 foreign import ccall "wrapper"
   wrap :: (CDouble -> Ptr CUChar -> CInt -> Ptr () -> IO ()) -> IO (FunPtr (CDouble -> Ptr CUChar -> CInt -> Ptr () -> IO ()))
 
-proxy :: (CDouble -> [CUChar] -> Ptr () -> IO ()) -> (CDouble -> Ptr CUChar -> CInt -> Ptr () -> IO ())
-proxy f t d s p = peekArray (fromIntegral s) d >>= \a -> f t a p
+proxy :: (Double -> [Word8] -> Ptr () -> IO ()) -> (CDouble -> Ptr CUChar -> CInt -> Ptr () -> IO ())
+proxy f (CDouble t) d s p = peekArray (fromIntegral s) d >>= \a -> f t (coerce a) p
 
--- |Set a callback function to be invoked for incoming MIDI messages.
--- 
+-- | Set a callback function to be invoked for incoming MIDI messages.
+--
 -- The callback function will be called whenever an incoming MIDI message is received.
 -- While not absolutely necessary, it is best to set the callback function before opening a MIDI port to avoid leaving
 -- some messages in the queue.
-setCallback :: Device
-            -> (CDouble -> [CUChar] -> IO ())  -- ^ Function that takes a timestamp and a MIDI message as arguments
+setCallback :: InputDevice
+            -> (Double -> [Word8] -> IO ())  -- ^ Function that takes a timestamp and a MIDI message as arguments
             -> IO ()
-setCallback d c = flip (rtmidi_in_set_callback (toInput d)) nullPtr =<< wrap (proxy ((const .) . c))
+setCallback d c = do
+  let dptr = toDevicePtr d
+  f <- wrap (proxy ((const .) . c))
+  rtmidi_in_set_callback dptr f nullPtr
+  guardError dptr
 
-
--- |See `setCallback`.
+-- | See `setCallback`.
 --
 -- Additionally a 'Ptr ()' is passed to the callback function whenever it is called.
-setCallbackWithUserData :: Device
-                        -> (CDouble -> [CUChar] -> Ptr () -> IO ())
+setCallbackWithUserData :: InputDevice
+                        -> (Double -> [Word8] -> Ptr () -> IO ())
                         -> Ptr ()
                         -> IO ()
-setCallbackWithUserData d c u = flip (rtmidi_in_set_callback (toInput d)) u =<< (wrap $ proxy c)
+setCallbackWithUserData d c u = do
+  let dptr = toDevicePtr d
+  f <- wrap (proxy c)
+  rtmidi_in_set_callback dptr f u
+  guardError dptr
 
--- |Cancel use of the current callback function (if one exists).
+-- | Cancel use of the current callback function (if one exists).
 --
 -- Subsequent incoming MIDI messages will be written to the queue and can be retrieved with the `getMessage` function.
-cancelCallback :: Device -> IO ()
-cancelCallback d = rtmidi_in_cancel_callback (toInput d)
+cancelCallback :: InputDevice -> IO ()
+cancelCallback d = do
+  let dptr = toDevicePtr d
+  rtmidi_in_cancel_callback dptr
+  guardError dptr
 
--- |Specify whether certain MIDI message types should be queued or ignored during input. 
+-- | Specify whether certain MIDI message types should be queued or ignored during input.
 --
 -- By default, MIDI timing and active sensing messages are ignored during message input because of their
 -- relative high data rates. MIDI sysex messages are ignored by default as well.
 -- Variable values of `true` imply that the respective message type will be ignored.
-ignoreTypes :: Device
+ignoreTypes :: InputDevice
             -> Bool       -- ^ SysEx messages
             -> Bool       -- ^ Time messages
             -> Bool       -- ^ Sense messages
             -> IO ()
-ignoreTypes d sysex time sense = rtmidi_in_ignore_types (toInput d) sysex time sense
+ignoreTypes = rtmidi_in_ignore_types . toDevicePtr
 
--- |Return data bytes for the next available MIDI message in the input queue and the event delta-time in seconds.
+-- | Return data bytes for the next available MIDI message in the input queue and the event delta-time in seconds.
 --
 -- This function returns immediately whether a new message is available or not.
 -- A valid message is indicated by whether the list contains any elements.
-getMessage :: Device -> IO ([CUChar], Double)
-getMessage d = alloca $ \m -> alloca $ \s -> do
-   timestamp <- rtmidi_in_get_message (toInput d) m s
-   size <- peek s
-   message <- peekArray (fromIntegral size) =<< peek m
-   return (message, toEnum $ fromEnum timestamp)
+getMessage :: InputDevice -> IO ([Word8], Double)
+getMessage d = allocaArray maxMessageSize $ flip with $ \m -> alloca $ \s -> do
+  let dptr = toDevicePtr d
+  poke s (fromIntegral maxMessageSize)
+  timestamp <- rtmidi_in_get_message dptr m s
+  guardError dptr
+  size <- peek s
+  message <-
+    case size of
+      0 -> pure []
+      _ -> do
+        x <- peek m
+        y <- peekArray (fromIntegral size) x
+        pure (coerce y)
+  pure (message, toEnum (fromEnum timestamp))
 
--- |Default constructor for a 'Device' to use for output.
-defaultOutput :: IO Device
-defaultOutput = Output <$> rtmidi_out_create_default
+-- | Default constructor for a 'Device' to use for output.
+defaultOutput :: IO OutputDevice
+defaultOutput = do
+  dptr <- rtmidi_out_create_default
+  guardError dptr
+  pure (OutputDevice (Device dptr))
 
--- |Create a new 'Device' to use for output.
+-- | Create a new 'Device' to use for output.
 createOutput :: Api        -- ^ API to use
              -> String     -- ^ client name
-             -> IO Device
-createOutput api clientName = Output <$>
-   (withCString clientName $ rtmidi_out_create (toEnum (fromEnum api)))
+             -> IO OutputDevice
+createOutput api clientName = do
+  dptr <- withCString clientName (rtmidi_out_create (toEnum (fromEnum api)))
+  guardError dptr
+  pure (OutputDevice (Device dptr))
 
--- |Immediately send a single message out an open MIDI output port. 
-sendMessage :: Device -> [CUChar] -> IO ()
-sendMessage d m = withArrayLen m $
-   \n ptr -> rtmidi_out_send_message (toOutput d) ptr (fromIntegral n) >> return ()
+-- | Immediately send a single message out an open MIDI output port.
+sendMessage :: OutputDevice -> [Word8] -> IO ()
+sendMessage d m = withArrayLen m $ \n ptr -> do
+  let dptr = toDevicePtr d
+  rtmidi_out_send_message dptr (coerce ptr) (fromIntegral n)
+  guardError dptr
 
--- |If a MIDI connection is still open, it will be closed
-closeInput (Input x) = rtmidi_in_free x
+-- | If a MIDI connection is still open, it will be closed
+closeDevice :: IsDevice d => d -> IO ()
+closeDevice d =
+  let dptr = toDevicePtr d
+  in case getDeviceType d of
+    InputDeviceType -> rtmidi_in_free dptr
+    OutputDeviceType -> rtmidi_out_free dptr
 
--- |Close any open MIDI connections
-closeOutput (Output x) = rtmidi_out_free x
-
--- |Returns the specifier for the MIDI 'Api' in use
-currentApi :: Device -> IO Api
-currentApi d = (toEnum . fromEnum) <$>
-   case d of
-      Input x -> rtmidi_in_get_current_api x
-      Output x -> rtmidi_out_get_current_api x
-
+-- | Returns the specifier for the MIDI 'Api' in use
+currentApi :: IsDevice d => d -> IO Api
+currentApi d = do
+  let dptr = toDevicePtr d
+  res <-
+    case getDeviceType d of
+      InputDeviceType -> rtmidi_in_get_current_api dptr
+      OutputDeviceType -> rtmidi_out_get_current_api dptr
+  guardError dptr
+  pure (toEnum (fromEnum res))

--- a/Sound/RtMidi/Foreign.hsc
+++ b/Sound/RtMidi/Foreign.hsc
@@ -55,9 +55,6 @@ instance Storable Wrapper where
 foreign import ccall "rtmidi_c.h rtmidi_close_port"
   rtmidi_close_port :: Ptr Wrapper -> IO ()
 
--- foreign import ccall "rtmidi_c.h rtmidi_error"
---   rtmidi_error :: Ptr Wrapper -> CInt -> CString -> IO ()
-
 foreign import ccall "rtmidi_c.h rtmidi_get_compiled_api"
   rtmidi_get_compiled_api :: Ptr (Ptr CInt) -> IO CInt
 

--- a/Sound/RtMidi/Foreign.hsc
+++ b/Sound/RtMidi/Foreign.hsc
@@ -1,0 +1,113 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+-- | FFI defs for RtMidi
+module Sound.RtMidi.Foreign
+  ( Wrapper (..)
+  , rtmidi_close_port
+  , rtmidi_get_compiled_api
+  , rtmidi_get_port_count
+  , rtmidi_get_port_name
+  , rtmidi_in_cancel_callback
+  , rtmidi_in_create
+  , rtmidi_in_create_default
+  , rtmidi_in_free
+  , rtmidi_in_get_current_api
+  , rtmidi_in_get_message
+  , rtmidi_in_ignore_types
+  , rtmidi_in_set_callback
+  , rtmidi_open_port
+  , rtmidi_open_virtual_port
+  , rtmidi_out_create
+  , rtmidi_out_create_default
+  , rtmidi_out_free
+  , rtmidi_out_get_current_api
+  , rtmidi_out_send_message
+  ) where
+
+#include "rtmidi_c.h"
+
+import Foreign (FunPtr, Ptr, Storable (..))
+import Foreign.C (CDouble (..), CInt (..), CString, CSize, CUChar)
+
+data Wrapper = Wrapper
+  { ptr :: !(Ptr ())
+  , dat :: !(Ptr ())
+  , ok  :: !Bool
+  , msg :: !CString
+  } deriving (Eq, Show)
+
+instance Storable Wrapper where
+  sizeOf _ = #{size struct RtMidiWrapper}
+  alignment _ = #{alignment struct RtMidiWrapper}
+  poke ptr (Wrapper a b c d) = do
+    #{poke struct RtMidiWrapper, ptr} ptr a
+    #{poke struct RtMidiWrapper, data} ptr b
+    #{poke struct RtMidiWrapper, ok} ptr c
+    #{poke struct RtMidiWrapper, msg} ptr d
+  peek ptr = do
+    a <- #{peek struct RtMidiWrapper, ptr} ptr
+    b <- #{peek struct RtMidiWrapper, data} ptr
+    c <- #{peek struct RtMidiWrapper, ok} ptr
+    d <- #{peek struct RtMidiWrapper, msg} ptr
+    pure (Wrapper a b c d)
+
+foreign import ccall "rtmidi_c.h rtmidi_close_port"
+  rtmidi_close_port :: Ptr Wrapper -> IO ()
+
+-- foreign import ccall "rtmidi_c.h rtmidi_error"
+--   rtmidi_error :: Ptr Wrapper -> CInt -> CString -> IO ()
+
+foreign import ccall "rtmidi_c.h rtmidi_get_compiled_api"
+  rtmidi_get_compiled_api :: Ptr (Ptr CInt) -> IO CInt
+
+foreign import ccall "rtmidi_c.h rtmidi_get_port_count"
+  rtmidi_get_port_count :: Ptr Wrapper -> IO CInt
+
+foreign import ccall "rtmidi_c.h rtmidi_get_port_name"
+  rtmidi_get_port_name :: Ptr Wrapper -> CInt -> IO CString
+
+foreign import ccall "rtmidi_c.h rtmidi_in_cancel_callback"
+  rtmidi_in_cancel_callback :: Ptr Wrapper -> IO ()
+
+foreign import ccall "rtmidi_c.h rtmidi_in_create"
+  rtmidi_in_create :: CInt -> CString -> CInt -> IO (Ptr Wrapper)
+
+foreign import ccall "rtmidi_c.h rtmidi_in_create_default"
+  rtmidi_in_create_default :: IO (Ptr Wrapper)
+
+foreign import ccall "rtmidi_c.h rtmidi_in_free"
+  rtmidi_in_free :: Ptr Wrapper -> IO ()
+
+foreign import ccall "rtmidi_c.h rtmidi_in_get_current_api"
+  rtmidi_in_get_current_api :: Ptr Wrapper -> IO CInt
+
+foreign import ccall "rtmidi_c.h rtmidi_in_get_message"
+  rtmidi_in_get_message :: Ptr Wrapper -> Ptr (Ptr CUChar) -> Ptr CSize -> IO CDouble
+
+foreign import ccall "rtmidi_c.h rtmidi_in_ignore_types"
+  rtmidi_in_ignore_types :: Ptr Wrapper -> Bool -> Bool -> Bool -> IO ()
+
+foreign import ccall "rtmidi_c.h rtmidi_in_set_callback"
+  rtmidi_in_set_callback :: Ptr Wrapper -> FunPtr (CDouble -> Ptr CUChar -> CInt -> Ptr () -> IO ()) -> Ptr () -> IO ()
+
+foreign import ccall "rtmidi_c.h rtmidi_open_port"
+  rtmidi_open_port :: Ptr Wrapper -> CInt -> CString -> IO ()
+
+foreign import ccall "rtmidi_c.h rtmidi_open_virtual_port"
+  rtmidi_open_virtual_port :: Ptr Wrapper -> CString -> IO ()
+
+foreign import ccall "rtmidi_c.h rtmidi_out_create"
+  rtmidi_out_create :: CInt -> CString -> IO (Ptr Wrapper)
+
+foreign import ccall "rtmidi_c.h rtmidi_out_create_default"
+  rtmidi_out_create_default :: IO (Ptr Wrapper)
+
+foreign import ccall "rtmidi_c.h rtmidi_out_free"
+  rtmidi_out_free :: Ptr Wrapper -> IO ()
+
+foreign import ccall "rtmidi_c.h rtmidi_out_get_current_api"
+  rtmidi_out_get_current_api :: Ptr Wrapper -> IO CInt
+
+foreign import ccall "rtmidi_c.h rtmidi_out_send_message"
+  rtmidi_out_send_message :: Ptr Wrapper -> Ptr CUChar -> CInt -> IO CInt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM haskell:8.8.4
+COPY packages.txt /tmp/packages.txt
+RUN apt-get update && \
+    apt-get install -y $(cat /tmp/packages.txt) && \
+    apt-get clean && \
+    rm /tmp/packages.txt

--- a/docker/packages.txt
+++ b/docker/packages.txt
@@ -1,0 +1,1 @@
+libasound2-dev libjack-dev

--- a/examples/callback.hs
+++ b/examples/callback.hs
@@ -1,8 +1,8 @@
-import Sound.RtMidi
-import Numeric
-import Foreign.C
+import Data.Word (Word8)
+import Sound.RtMidi (closeDevice, closePort, defaultInput, openPort, setCallback)
+import Numeric (showHex)
 
-callback :: CDouble -> [CUChar] -> IO ()
+callback :: Double -> [Word8] -> IO ()
 callback delta msg = putStrLn $ (foldr (showHex . fromEnum) "" msg) ++ " - " ++ (show delta)
 
 main :: IO ()
@@ -11,4 +11,6 @@ main = do
   openPort i 0 "RtMidi"
   setCallback i callback
   _ <- getLine
+  closePort i
+  closeDevice i
   return ()

--- a/examples/playback.hs
+++ b/examples/playback.hs
@@ -1,5 +1,5 @@
-import Sound.RtMidi
-import Control.Concurrent
+import Sound.RtMidi (closeDevice, closePort, defaultOutput, openPort, sendMessage, portCount, portName)
+import Control.Concurrent (threadDelay)
 
 main :: IO ()
 main = do
@@ -18,4 +18,4 @@ main = do
   mapM_ (\x -> sendMessage device [0x90, x, 0x7f] >> threadDelay 120000) $ take 240 song
   putStrLn "exiting..."
   closePort device
-  closeOutput device
+  closeDevice device

--- a/examples/poll.hs
+++ b/examples/poll.hs
@@ -1,10 +1,8 @@
-import Sound.RtMidi
-import Numeric
-import Control.Concurrent
-import Control.Monad
-import Foreign.C
+import Sound.RtMidi (InputDevice, closeDevice, closePort, defaultInput, getMessage, openPort)
+import Control.Concurrent (forkIO, killThread)
+import Control.Monad (forever)
 
-mainLoop :: Device -> IO ()
+mainLoop :: InputDevice -> IO ()
 mainLoop d = do
   m <- getMessage d
   if length (fst m) > 0 then
@@ -18,5 +16,6 @@ main = do
   id <- forkIO $ forever $ mainLoop i
   _ <- getLine
   killThread id
-  closeInput i
+  closePort i
+  closeDevice i
   return ()

--- a/examples/query.hs
+++ b/examples/query.hs
@@ -1,8 +1,8 @@
-import Sound.RtMidi
+import Sound.RtMidi (closeDevice, compiledApis, createOutput, currentApi, defaultOutput, portCount, portName)
 
 main :: IO ()
 main = do
-  device <- createOutput UnspecifiedApi "test"
+  device <- defaultOutput
   api <- currentApi device
   builtin <- compiledApis
   numPorts <- portCount device
@@ -11,4 +11,4 @@ main = do
   putStrLn $ "built-in: " ++ (show builtin)
   putStrLn $ "available Ports: " ++ (show numPorts)
   putStrLn (show portNames)
-  closeOutput device
+  closeDevice device

--- a/rtmidi/RtMidi.cpp
+++ b/rtmidi/RtMidi.cpp
@@ -5,10 +5,11 @@
     This class implements some common functionality for the realtime
     MIDI input/output subclasses RtMidiIn and RtMidiOut.
 
-    RtMidi WWW site: http://music.mcgill.ca/~gary/rtmidi/
+    RtMidi GitHub site: https://github.com/thestk/rtmidi
+    RtMidi WWW site: http://www.music.mcgill.ca/~gary/rtmidi/
 
     RtMidi: realtime MIDI i/o C++ classes
-    Copyright (c) 2003-2016 Gary P. Scavone
+    Copyright (c) 2003-2019 Gary P. Scavone
 
     Permission is hereby granted, free of charge, to any person
     obtaining a copy of this software and associated documentation files
@@ -46,6 +47,229 @@
   #endif
 #endif
 
+// Default for Windows is to add an identifier to the port names; this
+// flag can be defined (e.g. in your project file) to disable this behaviour.
+//#define RTMIDI_DO_NOT_ENSURE_UNIQUE_PORTNAMES
+
+// **************************************************************** //
+//
+// MidiInApi and MidiOutApi subclass prototypes.
+//
+// **************************************************************** //
+
+#if !defined(__LINUX_ALSA__) && !defined(__UNIX_JACK__) && !defined(__MACOSX_CORE__) && !defined(__WINDOWS_MM__)
+  #define __RTMIDI_DUMMY__
+#endif
+
+#if defined(__MACOSX_CORE__)
+
+class MidiInCore: public MidiInApi
+{
+ public:
+  MidiInCore( const std::string &clientName, unsigned int queueSizeLimit );
+  ~MidiInCore( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::MACOSX_CORE; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName );
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+
+ protected:
+  void initialize( const std::string& clientName );
+};
+
+class MidiOutCore: public MidiOutApi
+{
+ public:
+  MidiOutCore( const std::string &clientName );
+  ~MidiOutCore( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::MACOSX_CORE; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName );
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+  void sendMessage( const unsigned char *message, size_t size );
+
+ protected:
+  void initialize( const std::string& clientName );
+};
+
+#endif
+
+#if defined(__UNIX_JACK__)
+
+class MidiInJack: public MidiInApi
+{
+ public:
+  MidiInJack( const std::string &clientName, unsigned int queueSizeLimit );
+  ~MidiInJack( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::UNIX_JACK; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName);
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+
+ protected:
+  std::string clientName;
+
+  void connect( void );
+  void initialize( const std::string& clientName );
+};
+
+class MidiOutJack: public MidiOutApi
+{
+ public:
+  MidiOutJack( const std::string &clientName );
+  ~MidiOutJack( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::UNIX_JACK; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName);
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+  void sendMessage( const unsigned char *message, size_t size );
+
+ protected:
+  std::string clientName;
+
+  void connect( void );
+  void initialize( const std::string& clientName );
+};
+
+#endif
+
+#if defined(__LINUX_ALSA__)
+
+class MidiInAlsa: public MidiInApi
+{
+ public:
+  MidiInAlsa( const std::string &clientName, unsigned int queueSizeLimit );
+  ~MidiInAlsa( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::LINUX_ALSA; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName);
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+
+ protected:
+  void initialize( const std::string& clientName );
+};
+
+class MidiOutAlsa: public MidiOutApi
+{
+ public:
+  MidiOutAlsa( const std::string &clientName );
+  ~MidiOutAlsa( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::LINUX_ALSA; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName );
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+  void sendMessage( const unsigned char *message, size_t size );
+
+ protected:
+  void initialize( const std::string& clientName );
+};
+
+#endif
+
+#if defined(__WINDOWS_MM__)
+
+class MidiInWinMM: public MidiInApi
+{
+ public:
+  MidiInWinMM( const std::string &clientName, unsigned int queueSizeLimit );
+  ~MidiInWinMM( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::WINDOWS_MM; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName );
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+
+ protected:
+  void initialize( const std::string& clientName );
+};
+
+class MidiOutWinMM: public MidiOutApi
+{
+ public:
+  MidiOutWinMM( const std::string &clientName );
+  ~MidiOutWinMM( void );
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::WINDOWS_MM; };
+  void openPort( unsigned int portNumber, const std::string &portName );
+  void openVirtualPort( const std::string &portName );
+  void closePort( void );
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName );
+  unsigned int getPortCount( void );
+  std::string getPortName( unsigned int portNumber );
+  void sendMessage( const unsigned char *message, size_t size );
+
+ protected:
+  void initialize( const std::string& clientName );
+};
+
+#endif
+
+#if defined(__RTMIDI_DUMMY__)
+
+class MidiInDummy: public MidiInApi
+{
+ public:
+ MidiInDummy( const std::string &/*clientName*/, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit ) { errorString_ = "MidiInDummy: This class provides no functionality."; error( RtMidiError::WARNING, errorString_ ); }
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::RTMIDI_DUMMY; }
+  void openPort( unsigned int /*portNumber*/, const std::string &/*portName*/ ) {}
+  void openVirtualPort( const std::string &/*portName*/ ) {}
+  void closePort( void ) {}
+  void setClientName( const std::string &/*clientName*/ ) {};
+  void setPortName( const std::string &/*portName*/ ) {};
+  unsigned int getPortCount( void ) { return 0; }
+  std::string getPortName( unsigned int /*portNumber*/ ) { return ""; }
+
+ protected:
+  void initialize( const std::string& /*clientName*/ ) {}
+};
+
+class MidiOutDummy: public MidiOutApi
+{
+ public:
+  MidiOutDummy( const std::string &/*clientName*/ ) { errorString_ = "MidiOutDummy: This class provides no functionality."; error( RtMidiError::WARNING, errorString_ ); }
+  RtMidi::Api getCurrentApi( void ) { return RtMidi::RTMIDI_DUMMY; }
+  void openPort( unsigned int /*portNumber*/, const std::string &/*portName*/ ) {}
+  void openVirtualPort( const std::string &/*portName*/ ) {}
+  void closePort( void ) {}
+  void setClientName( const std::string &/*clientName*/ ) {};
+  void setPortName( const std::string &/*portName*/ ) {};
+  unsigned int getPortCount( void ) { return 0; }
+  std::string getPortName( unsigned int /*portNumber*/ ) { return ""; }
+  void sendMessage( const unsigned char * /*message*/, size_t /*size*/ ) {}
+
+ protected:
+  void initialize( const std::string& /*clientName*/ ) {}
+};
+
+#endif
+
 //*********************************************************************//
 //  RtMidi Definitions
 //*********************************************************************//
@@ -57,8 +281,7 @@ RtMidi :: RtMidi()
 
 RtMidi :: ~RtMidi()
 {
-  if ( rtapi_ )
-    delete rtapi_;
+  delete rtapi_;
   rtapi_ = 0;
 }
 
@@ -67,37 +290,99 @@ std::string RtMidi :: getVersion( void ) throw()
   return std::string( RTMIDI_VERSION );
 }
 
-void RtMidi :: getCompiledApi( std::vector<RtMidi::Api> &apis ) throw()
-{
-  apis.clear();
+// Define API names and display names.
+// Must be in same order as API enum.
+extern "C" {
+const char* rtmidi_api_names[][2] = {
+  { "unspecified" , "Unknown" },
+  { "core"        , "CoreMidi" },
+  { "alsa"        , "ALSA" },
+  { "jack"        , "Jack" },
+  { "winmm"       , "Windows MultiMedia" },
+  { "dummy"       , "Dummy" },
+};
+const unsigned int rtmidi_num_api_names =
+  sizeof(rtmidi_api_names)/sizeof(rtmidi_api_names[0]);
 
-  // The order here will control the order of RtMidi's API search in
-  // the constructor.
+// The order here will control the order of RtMidi's API search in
+// the constructor.
+extern "C" const RtMidi::Api rtmidi_compiled_apis[] = {
 #if defined(__MACOSX_CORE__)
-  apis.push_back( MACOSX_CORE );
+  RtMidi::MACOSX_CORE,
 #endif
 #if defined(__LINUX_ALSA__)
-  apis.push_back( LINUX_ALSA );
+  RtMidi::LINUX_ALSA,
 #endif
 #if defined(__UNIX_JACK__)
-  apis.push_back( UNIX_JACK );
+  RtMidi::UNIX_JACK,
 #endif
 #if defined(__WINDOWS_MM__)
-  apis.push_back( WINDOWS_MM );
+  RtMidi::WINDOWS_MM,
 #endif
 #if defined(__RTMIDI_DUMMY__)
-  apis.push_back( RTMIDI_DUMMY );
+  RtMidi::RTMIDI_DUMMY,
 #endif
+  RtMidi::UNSPECIFIED,
+};
+extern "C" const unsigned int rtmidi_num_compiled_apis =
+  sizeof(rtmidi_compiled_apis)/sizeof(rtmidi_compiled_apis[0])-1;
 }
+
+// This is a compile-time check that rtmidi_num_api_names == RtMidi::NUM_APIS.
+// If the build breaks here, check that they match.
+template<bool b> class StaticAssert { private: StaticAssert() {} };
+template<> class StaticAssert<true>{ public: StaticAssert() {} };
+class StaticAssertions { StaticAssertions() {
+  StaticAssert<rtmidi_num_api_names == RtMidi::NUM_APIS>();
+}};
+
+void RtMidi :: getCompiledApi( std::vector<RtMidi::Api> &apis ) throw()
+{
+  apis = std::vector<RtMidi::Api>(rtmidi_compiled_apis,
+                                  rtmidi_compiled_apis + rtmidi_num_compiled_apis);
+}
+
+std::string RtMidi :: getApiName( RtMidi::Api api )
+{
+  if (api < 0 || api >= RtMidi::NUM_APIS)
+    return "";
+  return rtmidi_api_names[api][0];
+}
+
+std::string RtMidi :: getApiDisplayName( RtMidi::Api api )
+{
+  if (api < 0 || api >= RtMidi::NUM_APIS)
+    return "Unknown";
+  return rtmidi_api_names[api][1];
+}
+
+RtMidi::Api RtMidi :: getCompiledApiByName( const std::string &name )
+{
+  unsigned int i=0;
+  for (i = 0; i < rtmidi_num_compiled_apis; ++i)
+    if (name == rtmidi_api_names[rtmidi_compiled_apis[i]][0])
+      return rtmidi_compiled_apis[i];
+  return RtMidi::UNSPECIFIED;
+}
+
+void RtMidi :: setClientName( const std::string &clientName )
+{
+  rtapi_->setClientName( clientName );
+}
+
+void RtMidi :: setPortName( const std::string &portName )
+{
+  rtapi_->setPortName( portName );
+}
+
 
 //*********************************************************************//
 //  RtMidiIn Definitions
 //*********************************************************************//
 
-void RtMidiIn :: openMidiApi( RtMidi::Api api, const std::string clientName, unsigned int queueSizeLimit )
+void RtMidiIn :: openMidiApi( RtMidi::Api api, const std::string &clientName, unsigned int queueSizeLimit )
 {
-  if ( rtapi_ )
-    delete rtapi_;
+  delete rtapi_;
   rtapi_ = 0;
 
 #if defined(__UNIX_JACK__)
@@ -122,7 +407,7 @@ void RtMidiIn :: openMidiApi( RtMidi::Api api, const std::string clientName, uns
 #endif
 }
 
-RtMidiIn :: RtMidiIn( RtMidi::Api api, const std::string clientName, unsigned int queueSizeLimit )
+RTMIDI_DLL_PUBLIC RtMidiIn :: RtMidiIn( RtMidi::Api api, const std::string &clientName, unsigned int queueSizeLimit )
   : RtMidi()
 {
   if ( api != UNSPECIFIED ) {
@@ -141,7 +426,7 @@ RtMidiIn :: RtMidiIn( RtMidi::Api api, const std::string clientName, unsigned in
   getCompiledApi( apis );
   for ( unsigned int i=0; i<apis.size(); i++ ) {
     openMidiApi( apis[i], clientName, queueSizeLimit );
-    if ( rtapi_->getPortCount() ) break;
+    if ( rtapi_ && rtapi_->getPortCount() ) break;
   }
 
   if ( rtapi_ ) return;
@@ -163,10 +448,9 @@ RtMidiIn :: ~RtMidiIn() throw()
 //  RtMidiOut Definitions
 //*********************************************************************//
 
-void RtMidiOut :: openMidiApi( RtMidi::Api api, const std::string clientName )
+void RtMidiOut :: openMidiApi( RtMidi::Api api, const std::string &clientName )
 {
-  if ( rtapi_ )
-    delete rtapi_;
+  delete rtapi_;
   rtapi_ = 0;
 
 #if defined(__UNIX_JACK__)
@@ -191,7 +475,7 @@ void RtMidiOut :: openMidiApi( RtMidi::Api api, const std::string clientName )
 #endif
 }
 
-RtMidiOut :: RtMidiOut( RtMidi::Api api, const std::string clientName )
+RTMIDI_DLL_PUBLIC RtMidiOut :: RtMidiOut( RtMidi::Api api, const std::string &clientName)
 {
   if ( api != UNSPECIFIED ) {
     // Attempt to open the specified API.
@@ -209,7 +493,7 @@ RtMidiOut :: RtMidiOut( RtMidi::Api api, const std::string clientName )
   getCompiledApi( apis );
   for ( unsigned int i=0; i<apis.size(); i++ ) {
     openMidiApi( apis[i], clientName );
-    if ( rtapi_->getPortCount() ) break;
+    if ( rtapi_ && rtapi_->getPortCount() ) break;
   }
 
   if ( rtapi_ ) return;
@@ -255,7 +539,7 @@ void MidiApi :: error( RtMidiError::Type type, std::string errorString )
     firstErrorOccurred_ = true;
     const std::string errorMessage = errorString;
 
-    errorCallback_( type, errorMessage, errorCallbackUserData_);
+    errorCallback_( type, errorMessage, errorCallbackUserData_ );
     firstErrorOccurred_ = false;
     return;
   }
@@ -343,18 +627,68 @@ double MidiInApi :: getMessage( std::vector<unsigned char> *message )
     return 0.0;
   }
 
-  if ( inputData_.queue.size == 0 ) return 0.0;
+  double timeStamp;
+  if ( !inputData_.queue.pop( message, &timeStamp ) )
+    return 0.0;
+
+  return timeStamp;
+}
+
+unsigned int MidiInApi::MidiQueue::size( unsigned int *__back,
+                                         unsigned int *__front )
+{
+  // Access back/front members exactly once and make stack copies for
+  // size calculation
+  unsigned int _back = back, _front = front, _size;
+  if ( _back >= _front )
+    _size = _back - _front;
+  else
+    _size = ringSize - _front + _back;
+
+  // Return copies of back/front so no new and unsynchronized accesses
+  // to member variables are needed.
+  if ( __back ) *__back = _back;
+  if ( __front ) *__front = _front;
+  return _size;
+}
+
+// As long as we haven't reached our queue size limit, push the message.
+bool MidiInApi::MidiQueue::push( const MidiInApi::MidiMessage& msg )
+{
+  // Local stack copies of front/back
+  unsigned int _back, _front, _size;
+
+  // Get back/front indexes exactly once and calculate current size
+  _size = size( &_back, &_front );
+
+  if ( _size < ringSize-1 )
+  {
+    ring[_back] = msg;
+    back = (back+1)%ringSize;
+    return true;
+  }
+
+  return false;
+}
+
+bool MidiInApi::MidiQueue::pop( std::vector<unsigned char> *msg, double* timeStamp )
+{
+  // Local stack copies of front/back
+  unsigned int _back, _front, _size;
+
+  // Get back/front indexes exactly once and calculate current size
+  _size = size( &_back, &_front );
+
+  if ( _size == 0 )
+    return false;
 
   // Copy queued message to the vector pointer argument and then "pop" it.
-  std::vector<unsigned char> *bytes = &(inputData_.queue.ring[inputData_.queue.front].bytes);
-  message->assign( bytes->begin(), bytes->end() );
-  double deltaTime = inputData_.queue.ring[inputData_.queue.front].timeStamp;
-  inputData_.queue.size--;
-  inputData_.queue.front++;
-  if ( inputData_.queue.front == inputData_.queue.ringSize )
-    inputData_.queue.front = 0;
+  msg->assign( ring[_front].bytes.begin(), ring[_front].bytes.end() );
+  *timeStamp = ring[_front].timeStamp;
 
-  return deltaTime;
+  // Update front
+  front = (front+1)%ringSize;
+  return true;
 }
 
 //*********************************************************************//
@@ -428,10 +762,12 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
     // function.
 
     nBytes = packet->length;
-    if ( nBytes == 0 ) continue;
+    if ( nBytes == 0 ) {
+      packet = MIDIPacketNext( packet );
+      continue;
+    }
 
     // Calculate time stamp.
-
     if ( data->firstMessage ) {
       message.timeStamp = 0.0;
       data->firstMessage = false;
@@ -446,11 +782,10 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
       if ( !continueSysex )
         message.timeStamp = time * 0.000000001;
     }
-    apiData->lastTime = packet->timeStamp;
-    if ( apiData->lastTime == 0 ) { // this happens when receiving asynchronous sysex messages
-      apiData->lastTime = AudioGetCurrentHostTime();
-    }
-    //std::cout << "TimeStamp = " << packet->timeStamp << std::endl;
+
+    // Track whether any non-filtered messages were found in this
+    // packet for timestamp calculation
+    bool foundNonFiltered = false;
 
     iByte = 0;
     if ( continueSysex ) {
@@ -470,13 +805,7 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
         }
         else {
           // As long as we haven't reached our queue size limit, push the message.
-          if ( data->queue.size < data->queue.ringSize ) {
-            data->queue.ring[data->queue.back++] = message;
-            if ( data->queue.back == data->queue.ringSize )
-              data->queue.back = 0;
-            data->queue.size++;
-          }
-          else
+          if ( !data->queue.push( message ) )
             std::cerr << "\nMidiInCore: message queue limit reached!!\n\n";
         }
         message.bytes.clear();
@@ -502,12 +831,12 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
           continueSysex = packet->data[nBytes-1] != 0xF7;
         }
         else if ( status == 0xF1 ) {
-            // A MIDI time code message
-           if ( data->ignoreFlags & 0x02 ) {
+          // A MIDI time code message
+          if ( data->ignoreFlags & 0x02 ) {
             size = 0;
             iByte += 2;
-           }
-           else size = 2;
+          }
+          else size = 2;
         }
         else if ( status == 0xF2 ) size = 3;
         else if ( status == 0xF3 ) size = 2;
@@ -525,6 +854,7 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
 
         // Copy the MIDI data to our vector.
         if ( size ) {
+          foundNonFiltered = true;
           message.bytes.assign( &packet->data[iByte], &packet->data[iByte+size] );
           if ( !continueSysex ) {
             // If not a continuing sysex message, invoke the user callback function or queue the message.
@@ -534,13 +864,7 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
             }
             else {
               // As long as we haven't reached our queue size limit, push the message.
-              if ( data->queue.size < data->queue.ringSize ) {
-                data->queue.ring[data->queue.back++] = message;
-                if ( data->queue.back == data->queue.ringSize )
-                  data->queue.back = 0;
-                data->queue.size++;
-              }
-              else
+              if ( !data->queue.push( message ) )
                 std::cerr << "\nMidiInCore: message queue limit reached!!\n\n";
             }
             message.bytes.clear();
@@ -549,19 +873,29 @@ static void midiInputCallback( const MIDIPacketList *list, void *procRef, void *
         }
       }
     }
+
+    // Save the time of the last non-filtered message
+    if ( foundNonFiltered ) {
+      apiData->lastTime = packet->timeStamp;
+      if ( apiData->lastTime == 0 ) { // this happens when receiving asynchronous sysex messages
+        apiData->lastTime = AudioGetCurrentHostTime();
+      }
+    }
+
     packet = MIDIPacketNext(packet);
   }
 }
 
-MidiInCore :: MidiInCore( const std::string clientName, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit )
+MidiInCore :: MidiInCore( const std::string &clientName, unsigned int queueSizeLimit )
+  : MidiInApi( queueSizeLimit )
 {
-  initialize( clientName );
+  MidiInCore::initialize( clientName );
 }
 
 MidiInCore :: ~MidiInCore( void )
 {
   // Close a connection if it exists.
-  closePort();
+  MidiInCore::closePort();
 
   // Cleanup.
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
@@ -590,10 +924,10 @@ void MidiInCore :: initialize( const std::string& clientName )
   data->endpoint = 0;
   apiData_ = (void *) data;
   inputData_.apiData = (void *) data;
-  CFRelease(name);
+  CFRelease( name );
 }
 
-void MidiInCore :: openPort( unsigned int portNumber, const std::string portName )
+void MidiInCore :: openPort( unsigned int portNumber, const std::string &portName )
 {
   if ( connected_ ) {
     errorString_ = "MidiInCore::openPort: a valid connection already exists!";
@@ -603,7 +937,7 @@ void MidiInCore :: openPort( unsigned int portNumber, const std::string portName
 
   CFRunLoopRunInMode( kCFRunLoopDefaultMode, 0, false );
   unsigned int nSrc = MIDIGetNumberOfSources();
-  if (nSrc < 1) {
+  if ( nSrc < 1 ) {
     errorString_ = "MidiInCore::openPort: no MIDI input sources found!";
     error( RtMidiError::NO_DEVICES_FOUND, errorString_ );
     return;
@@ -619,9 +953,12 @@ void MidiInCore :: openPort( unsigned int portNumber, const std::string portName
 
   MIDIPortRef port;
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
-  OSStatus result = MIDIInputPortCreate( data->client, 
-                                         CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII ),
+  CFStringRef portNameRef = CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII );
+  OSStatus result = MIDIInputPortCreate( data->client,
+                                         portNameRef,
                                          midiInputCallback, (void *)&inputData_, &port );
+  CFRelease( portNameRef );
+
   if ( result != noErr ) {
     MIDIClientDispose( data->client );
     errorString_ = "MidiInCore::openPort: error creating OS-X MIDI input port.";
@@ -655,15 +992,18 @@ void MidiInCore :: openPort( unsigned int portNumber, const std::string portName
   connected_ = true;
 }
 
-void MidiInCore :: openVirtualPort( const std::string portName )
+void MidiInCore :: openVirtualPort( const std::string &portName )
 {
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
 
   // Create a virtual MIDI input destination.
   MIDIEndpointRef endpoint;
+  CFStringRef portNameRef = CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII );
   OSStatus result = MIDIDestinationCreate( data->client,
-                                           CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII ),
+                                           portNameRef,
                                            midiInputCallback, (void *)&inputData_, &endpoint );
+  CFRelease( portNameRef );
+
   if ( result != noErr ) {
     errorString_ = "MidiInCore::openVirtualPort: error creating virtual OS-X MIDI destination.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -680,13 +1020,31 @@ void MidiInCore :: closePort( void )
 
   if ( data->endpoint ) {
     MIDIEndpointDispose( data->endpoint );
+    data->endpoint = 0;
   }
 
   if ( data->port ) {
     MIDIPortDispose( data->port );
+    data->port = 0;
   }
 
   connected_ = false;
+}
+
+void MidiInCore :: setClientName ( const std::string& )
+{
+
+  errorString_ = "MidiInCore::setClientName: this function is not implemented for the MACOSX_CORE API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiInCore :: setPortName ( const std::string& )
+{
+
+  errorString_ = "MidiInCore::setPortName: this function is not implemented for the MACOSX_CORE API!";
+  error( RtMidiError::WARNING, errorString_ );
+
 }
 
 unsigned int MidiInCore :: getPortCount()
@@ -751,12 +1109,13 @@ CFStringRef EndpointName( MIDIEndpointRef endpoint, bool isExternal )
       // does the entity name already start with the device name?
       // (some drivers do this though they shouldn't)
       // if so, do not prepend
-        if ( CFStringCompareWithOptions( result, /* endpoint name */
-             str /* device name */,
-             CFRangeMake(0, CFStringGetLength( str ) ), 0 ) != kCFCompareEqualTo ) {
+      if ( CFStringCompareWithOptions( result, /* endpoint name */
+                                       str /* device name */,
+                                       CFRangeMake(0, CFStringGetLength( str ) ), 0 ) != kCFCompareEqualTo ) {
         // prepend the device name to the entity name
         if ( CFStringGetLength( result ) > 0 )
           CFStringInsert( result, 0, CFSTR(" ") );
+
         CFStringInsert( result, 0, str );
       }
       CFRelease( str );
@@ -792,7 +1151,7 @@ static CFStringRef ConnectedEndpointName( MIDIEndpointRef endpoint )
         err = MIDIObjectFindByUniqueID( id, &connObject, &connObjectType );
         if ( err == noErr ) {
           if ( connObjectType == kMIDIObjectType_ExternalSource  ||
-              connObjectType == kMIDIObjectType_ExternalDestination ) {
+               connObjectType == kMIDIObjectType_ExternalDestination ) {
             // Connected to an external device's endpoint (10.3 and later).
             str = EndpointName( (MIDIEndpointRef)(connObject), true );
           } else {
@@ -803,7 +1162,8 @@ static CFStringRef ConnectedEndpointName( MIDIEndpointRef endpoint )
           if ( str != NULL ) {
             if ( anyStrings )
               CFStringAppend( result, CFSTR(", ") );
-            else anyStrings = true;
+            else
+              anyStrings = true;
             CFStringAppend( result, str );
             CFRelease( str );
           }
@@ -817,7 +1177,7 @@ static CFStringRef ConnectedEndpointName( MIDIEndpointRef endpoint )
 
   CFRelease( result );
 
-  // Here, either the endpoint had no connections, or we failed to obtain names 
+  // Here, either the endpoint had no connections, or we failed to obtain names
   return EndpointName( endpoint, false );
 }
 
@@ -838,8 +1198,8 @@ std::string MidiInCore :: getPortName( unsigned int portNumber )
   }
 
   portRef = MIDIGetSource( portNumber );
-  nameRef = ConnectedEndpointName(portRef);
-  CFStringGetCString( nameRef, name, sizeof(name), CFStringGetSystemEncoding());
+  nameRef = ConnectedEndpointName( portRef );
+  CFStringGetCString( nameRef, name, sizeof(name), kCFStringEncodingUTF8 );
   CFRelease( nameRef );
 
   return stringName = name;
@@ -850,15 +1210,16 @@ std::string MidiInCore :: getPortName( unsigned int portNumber )
 //  Class Definitions: MidiOutCore
 //*********************************************************************//
 
-MidiOutCore :: MidiOutCore( const std::string clientName ) : MidiOutApi()
+MidiOutCore :: MidiOutCore( const std::string &clientName )
+  : MidiOutApi()
 {
-  initialize( clientName );
+  MidiOutCore::initialize( clientName );
 }
 
 MidiOutCore :: ~MidiOutCore( void )
 {
   // Close a connection if it exists.
-  closePort();
+  MidiOutCore::closePort();
 
   // Cleanup.
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
@@ -913,13 +1274,13 @@ std::string MidiOutCore :: getPortName( unsigned int portNumber )
 
   portRef = MIDIGetDestination( portNumber );
   nameRef = ConnectedEndpointName(portRef);
-  CFStringGetCString( nameRef, name, sizeof(name), CFStringGetSystemEncoding());
+  CFStringGetCString( nameRef, name, sizeof(name), kCFStringEncodingUTF8 );
   CFRelease( nameRef );
-  
+
   return stringName = name;
 }
 
-void MidiOutCore :: openPort( unsigned int portNumber, const std::string portName )
+void MidiOutCore :: openPort( unsigned int portNumber, const std::string &portName )
 {
   if ( connected_ ) {
     errorString_ = "MidiOutCore::openPort: a valid connection already exists!";
@@ -945,9 +1306,9 @@ void MidiOutCore :: openPort( unsigned int portNumber, const std::string portNam
 
   MIDIPortRef port;
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
-  OSStatus result = MIDIOutputPortCreate( data->client, 
-                                          CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII ),
-                                          &port );
+  CFStringRef portNameRef = CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII );
+  OSStatus result = MIDIOutputPortCreate( data->client, portNameRef, &port );
+  CFRelease( portNameRef );
   if ( result != noErr ) {
     MIDIClientDispose( data->client );
     errorString_ = "MidiOutCore::openPort: error creating OS-X MIDI output port.";
@@ -977,16 +1338,34 @@ void MidiOutCore :: closePort( void )
 
   if ( data->endpoint ) {
     MIDIEndpointDispose( data->endpoint );
+    data->endpoint = 0;
   }
 
   if ( data->port ) {
     MIDIPortDispose( data->port );
+    data->port = 0;
   }
 
   connected_ = false;
 }
 
-void MidiOutCore :: openVirtualPort( std::string portName )
+void MidiOutCore :: setClientName ( const std::string& )
+{
+
+  errorString_ = "MidiOutCore::setClientName: this function is not implemented for the MACOSX_CORE API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiOutCore :: setPortName ( const std::string& )
+{
+
+  errorString_ = "MidiOutCore::setPortName: this function is not implemented for the MACOSX_CORE API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiOutCore :: openVirtualPort( const std::string &portName )
 {
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
 
@@ -998,9 +1377,10 @@ void MidiOutCore :: openVirtualPort( std::string portName )
 
   // Create a virtual MIDI output source.
   MIDIEndpointRef endpoint;
-  OSStatus result = MIDISourceCreate( data->client,
-                                      CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII ),
-                                      &endpoint );
+  CFStringRef portNameRef = CFStringCreateWithCString( NULL, portName.c_str(), kCFStringEncodingASCII );
+  OSStatus result = MIDISourceCreate( data->client, portNameRef, &endpoint );
+  CFRelease( portNameRef );
+
   if ( result != noErr ) {
     errorString_ = "MidiOutCore::initialize: error creating OS-X virtual MIDI source.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -1011,13 +1391,13 @@ void MidiOutCore :: openVirtualPort( std::string portName )
   data->endpoint = endpoint;
 }
 
-void MidiOutCore :: sendMessage( std::vector<unsigned char> *message )
+void MidiOutCore :: sendMessage( const unsigned char *message, size_t size )
 {
   // We use the MIDISendSysex() function to asynchronously send sysex
   // messages.  Otherwise, we use a single CoreMidi MIDIPacket.
-  unsigned int nBytes = message->size();
+  unsigned int nBytes = static_cast<unsigned int> (size);
   if ( nBytes == 0 ) {
-    errorString_ = "MidiOutCore::sendMessage: no data in message argument!";      
+    errorString_ = "MidiOutCore::sendMessage: no data in message argument!";
     error( RtMidiError::WARNING, errorString_ );
     return;
   }
@@ -1026,27 +1406,27 @@ void MidiOutCore :: sendMessage( std::vector<unsigned char> *message )
   CoreMidiData *data = static_cast<CoreMidiData *> (apiData_);
   OSStatus result;
 
-  if ( message->at(0) != 0xF0 && nBytes > 3 ) {
+  if ( message[0] != 0xF0 && nBytes > 3 ) {
     errorString_ = "MidiOutCore::sendMessage: message format problem ... not sysex but > 3 bytes?";
     error( RtMidiError::WARNING, errorString_ );
     return;
   }
 
-  Byte buffer[nBytes+(sizeof(MIDIPacketList))];
-  ByteCount listSize = sizeof(buffer);
+  Byte buffer[nBytes+(sizeof( MIDIPacketList ))];
+  ByteCount listSize = sizeof( buffer );
   MIDIPacketList *packetList = (MIDIPacketList*)buffer;
   MIDIPacket *packet = MIDIPacketListInit( packetList );
 
   ByteCount remainingBytes = nBytes;
-  while (remainingBytes && packet) {
+  while ( remainingBytes && packet ) {
     ByteCount bytesForPacket = remainingBytes > 65535 ? 65535 : remainingBytes; // 65535 = maximum size of a MIDIPacket
-    const Byte* dataStartPtr = (const Byte *) &message->at( nBytes - remainingBytes );
-    packet = MIDIPacketListAdd( packetList, listSize, packet, timeStamp, bytesForPacket, dataStartPtr);
-    remainingBytes -= bytesForPacket; 
+    const Byte* dataStartPtr = (const Byte *) &message[nBytes - remainingBytes];
+    packet = MIDIPacketListAdd( packetList, listSize, packet, timeStamp, bytesForPacket, dataStartPtr );
+    remainingBytes -= bytesForPacket;
   }
 
   if ( !packet ) {
-    errorString_ = "MidiOutCore::sendMessage: could not allocate packet list";      
+    errorString_ = "MidiOutCore::sendMessage: could not allocate packet list";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
   }
@@ -1110,7 +1490,7 @@ struct AlsaMidiData {
   unsigned char *buffer;
   pthread_t thread;
   pthread_t dummy_thread_id;
-  unsigned long long lastTime;
+  snd_seq_real_time_t lastTime;
   int queue_id; // an input queue is needed to get timestamped events
   int trigger_fds[2];
 };
@@ -1128,7 +1508,7 @@ static void *alsaMidiHandler( void *ptr )
   AlsaMidiData *apiData = static_cast<AlsaMidiData *> (data->apiData);
 
   long nBytes;
-  unsigned long long time, lastTime;
+  double time;
   bool continueSysex = false;
   bool doDecode = false;
   MidiInApi::MidiMessage message;
@@ -1227,7 +1607,7 @@ static void *alsaMidiHandler( void *ptr )
       if ( !( data->ignoreFlags & 0x04 ) ) doDecode = true;
       break;
 
-		case SND_SEQ_EVENT_SYSEX:
+    case SND_SEQ_EVENT_SYSEX:
       if ( (data->ignoreFlags & 0x01) ) break;
       if ( ev->data.ext.len > apiData->bufferSize ) {
         apiData->bufferSize = ev->data.ext.len;
@@ -1239,6 +1619,8 @@ static void *alsaMidiHandler( void *ptr )
           break;
         }
       }
+      doDecode = true;
+      break;
 
     default:
       doDecode = true;
@@ -1270,14 +1652,37 @@ static void *alsaMidiHandler( void *ptr )
 
           // Method 2: Use the ALSA sequencer event time data.
           // (thanks to Pedro Lopez-Cabanillas!).
-          time = ( ev->time.time.tv_sec * 1000000 ) + ( ev->time.time.tv_nsec/1000 );
-          lastTime = time;
-          time -= apiData->lastTime;
-          apiData->lastTime = lastTime;
+
+          // Using method from:
+          // https://www.gnu.org/software/libc/manual/html_node/Elapsed-Time.html
+
+          // Perform the carry for the later subtraction by updating y.
+          // Temp var y is timespec because computation requires signed types,
+          // while snd_seq_real_time_t has unsigned types.
+          snd_seq_real_time_t &x( ev->time.time );
+          struct timespec y;
+          y.tv_nsec = apiData->lastTime.tv_nsec;
+          y.tv_sec = apiData->lastTime.tv_sec;
+          if ( x.tv_nsec < y.tv_nsec ) {
+              int nsec = (y.tv_nsec - (int)x.tv_nsec) / 1000000000 + 1;
+              y.tv_nsec -= 1000000000 * nsec;
+              y.tv_sec += nsec;
+          }
+          if ( x.tv_nsec - y.tv_nsec > 1000000000 ) {
+              int nsec = ((int)x.tv_nsec - y.tv_nsec) / 1000000000;
+              y.tv_nsec += 1000000000 * nsec;
+              y.tv_sec -= nsec;
+          }
+
+          // Compute the time difference.
+          time = (int)x.tv_sec - y.tv_sec + ((int)x.tv_nsec - y.tv_nsec)*1e-9;
+
+          apiData->lastTime = ev->time.time;
+
           if ( data->firstMessage == true )
             data->firstMessage = false;
           else
-            message.timeStamp = time * 0.000001;
+            message.timeStamp = time;
         }
         else {
 #if defined(__RTMIDI_DEBUG__)
@@ -1296,13 +1701,7 @@ static void *alsaMidiHandler( void *ptr )
     }
     else {
       // As long as we haven't reached our queue size limit, push the message.
-      if ( data->queue.size < data->queue.ringSize ) {
-        data->queue.ring[data->queue.back++] = message;
-        if ( data->queue.back == data->queue.ringSize )
-          data->queue.back = 0;
-        data->queue.size++;
-      }
-      else
+      if ( !data->queue.push( message ) )
         std::cerr << "\nMidiInAlsa: message queue limit reached!!\n\n";
     }
   }
@@ -1314,21 +1713,22 @@ static void *alsaMidiHandler( void *ptr )
   return 0;
 }
 
-MidiInAlsa :: MidiInAlsa( const std::string clientName, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit )
+MidiInAlsa :: MidiInAlsa( const std::string &clientName, unsigned int queueSizeLimit )
+  : MidiInApi( queueSizeLimit )
 {
-  initialize( clientName );
+  MidiInAlsa::initialize( clientName );
 }
 
 MidiInAlsa :: ~MidiInAlsa()
 {
   // Close a connection if it exists.
-  closePort();
+  MidiInAlsa::closePort();
 
   // Shutdown the input thread.
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( inputData_.doInput ) {
     inputData_.doInput = false;
-    int res = write( data->trigger_fds[1], &inputData_.doInput, sizeof(inputData_.doInput) );
+    int res = write( data->trigger_fds[1], &inputData_.doInput, sizeof( inputData_.doInput ) );
     (void) res;
     if ( !pthread_equal(data->thread, data->dummy_thread_id) )
       pthread_join( data->thread, NULL );
@@ -1349,7 +1749,7 @@ void MidiInAlsa :: initialize( const std::string& clientName )
 {
   // Set up the ALSA sequencer client.
   snd_seq_t *seq;
-  int result = snd_seq_open(&seq, "default", SND_SEQ_OPEN_DUPLEX, SND_SEQ_NONBLOCK);
+  int result = snd_seq_open( &seq, "default", SND_SEQ_OPEN_DUPLEX, SND_SEQ_NONBLOCK );
   if ( result < 0 ) {
     errorString_ = "MidiInAlsa::initialize: error creating ALSA sequencer client object.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -1372,7 +1772,7 @@ void MidiInAlsa :: initialize( const std::string& clientName )
   apiData_ = (void *) data;
   inputData_.apiData = (void *) data;
 
-   if ( pipe(data->trigger_fds) == -1 ) {
+  if ( pipe(data->trigger_fds) == -1 ) {
     errorString_ = "MidiInAlsa::initialize: error creating pipe objects.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
@@ -1380,14 +1780,14 @@ void MidiInAlsa :: initialize( const std::string& clientName )
 
   // Create the input queue
 #ifndef AVOID_TIMESTAMPING
-  data->queue_id = snd_seq_alloc_named_queue(seq, "RtMidi Queue");
+  data->queue_id = snd_seq_alloc_named_queue( seq, "RtMidi Queue" );
   // Set arbitrary tempo (mm=100) and resolution (240)
   snd_seq_queue_tempo_t *qtempo;
-  snd_seq_queue_tempo_alloca(&qtempo);
-  snd_seq_queue_tempo_set_tempo(qtempo, 600000);
-  snd_seq_queue_tempo_set_ppq(qtempo, 240);
-  snd_seq_set_queue_tempo(data->seq, data->queue_id, qtempo);
-  snd_seq_drain_output(data->seq);
+  snd_seq_queue_tempo_alloca( &qtempo );
+  snd_seq_queue_tempo_set_tempo( qtempo, 600000 );
+  snd_seq_queue_tempo_set_ppq( qtempo, 240 );
+  snd_seq_set_queue_tempo( data->seq, data->queue_id, qtempo );
+  snd_seq_drain_output( data->seq );
 #endif
 }
 
@@ -1409,7 +1809,9 @@ unsigned int portInfo( snd_seq_t *seq, snd_seq_port_info_t *pinfo, unsigned int 
     while ( snd_seq_query_next_port( seq, pinfo ) >= 0 ) {
       unsigned int atyp = snd_seq_port_info_get_type( pinfo );
       if ( ( ( atyp & SND_SEQ_PORT_TYPE_MIDI_GENERIC ) == 0 ) &&
-        ( ( atyp & SND_SEQ_PORT_TYPE_SYNTH ) == 0 ) ) continue;
+           ( ( atyp & SND_SEQ_PORT_TYPE_SYNTH ) == 0 ) &&
+           ( ( atyp & SND_SEQ_PORT_TYPE_APPLICATION ) == 0 ) ) continue;
+
       unsigned int caps = snd_seq_port_info_get_capability( pinfo );
       if ( ( caps & type ) != type ) continue;
       if ( count == portNumber ) return 1;
@@ -1445,6 +1847,8 @@ std::string MidiInAlsa :: getPortName( unsigned int portNumber )
     snd_seq_get_any_client_info( data->seq, cnum, cinfo );
     std::ostringstream os;
     os << snd_seq_client_info_get_name( cinfo );
+    os << ":";
+    os << snd_seq_port_info_get_name( pinfo );
     os << " ";                                    // These lines added to make sure devices are listed
     os << snd_seq_port_info_get_client( pinfo );  // with full portnames added to ensure individual device names
     os << ":";
@@ -1459,7 +1863,7 @@ std::string MidiInAlsa :: getPortName( unsigned int portNumber )
   return stringName;
 }
 
-void MidiInAlsa :: openPort( unsigned int portNumber, const std::string portName )
+void MidiInAlsa :: openPort( unsigned int portNumber, const std::string &portName )
 {
   if ( connected_ ) {
     errorString_ = "MidiInAlsa::openPort: a valid connection already exists!";
@@ -1503,33 +1907,33 @@ void MidiInAlsa :: openPort( unsigned int portNumber, const std::string portName
                                 SND_SEQ_PORT_TYPE_APPLICATION );
     snd_seq_port_info_set_midi_channels(pinfo, 16);
 #ifndef AVOID_TIMESTAMPING
-    snd_seq_port_info_set_timestamping(pinfo, 1);
-    snd_seq_port_info_set_timestamp_real(pinfo, 1);    
-    snd_seq_port_info_set_timestamp_queue(pinfo, data->queue_id);
+    snd_seq_port_info_set_timestamping( pinfo, 1 );
+    snd_seq_port_info_set_timestamp_real( pinfo, 1 );
+    snd_seq_port_info_set_timestamp_queue( pinfo, data->queue_id );
 #endif
-    snd_seq_port_info_set_name(pinfo,  portName.c_str() );
-    data->vport = snd_seq_create_port(data->seq, pinfo);
-  
+    snd_seq_port_info_set_name( pinfo,  portName.c_str() );
+    data->vport = snd_seq_create_port( data->seq, pinfo );
+
     if ( data->vport < 0 ) {
       errorString_ = "MidiInAlsa::openPort: ALSA error creating input port.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
     }
-    data->vport = snd_seq_port_info_get_port(pinfo);
+    data->vport = snd_seq_port_info_get_port( pinfo );
   }
 
   receiver.port = data->vport;
 
   if ( !data->subscription ) {
     // Make subscription
-    if (snd_seq_port_subscribe_malloc( &data->subscription ) < 0) {
+    if ( snd_seq_port_subscribe_malloc( &data->subscription ) < 0 ) {
       errorString_ = "MidiInAlsa::openPort: ALSA error allocation port subscription.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
     }
-    snd_seq_port_subscribe_set_sender(data->subscription, &sender);
-    snd_seq_port_subscribe_set_dest(data->subscription, &receiver);
-    if ( snd_seq_subscribe_port(data->seq, data->subscription) ) {
+    snd_seq_port_subscribe_set_sender( data->subscription, &sender );
+    snd_seq_port_subscribe_set_dest( data->subscription, &receiver );
+    if ( snd_seq_subscribe_port( data->seq, data->subscription ) ) {
       snd_seq_port_subscribe_free( data->subscription );
       data->subscription = 0;
       errorString_ = "MidiInAlsa::openPort: ALSA error making port connection.";
@@ -1546,13 +1950,13 @@ void MidiInAlsa :: openPort( unsigned int portNumber, const std::string portName
 #endif
     // Start our MIDI input thread.
     pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-    pthread_attr_setschedpolicy(&attr, SCHED_OTHER);
+    pthread_attr_init( &attr );
+    pthread_attr_setdetachstate( &attr, PTHREAD_CREATE_JOINABLE );
+    pthread_attr_setschedpolicy( &attr, SCHED_OTHER );
 
     inputData_.doInput = true;
-    int err = pthread_create(&data->thread, &attr, alsaMidiHandler, &inputData_);
-    pthread_attr_destroy(&attr);
+    int err = pthread_create( &data->thread, &attr, alsaMidiHandler, &inputData_ );
+    pthread_attr_destroy( &attr );
     if ( err ) {
       snd_seq_unsubscribe_port( data->seq, data->subscription );
       snd_seq_port_subscribe_free( data->subscription );
@@ -1567,38 +1971,38 @@ void MidiInAlsa :: openPort( unsigned int portNumber, const std::string portName
   connected_ = true;
 }
 
-void MidiInAlsa :: openVirtualPort( std::string portName )
+void MidiInAlsa :: openVirtualPort( const std::string &portName )
 {
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( data->vport < 0 ) {
     snd_seq_port_info_t *pinfo;
     snd_seq_port_info_alloca( &pinfo );
     snd_seq_port_info_set_capability( pinfo,
-				      SND_SEQ_PORT_CAP_WRITE |
-				      SND_SEQ_PORT_CAP_SUBS_WRITE );
+                                      SND_SEQ_PORT_CAP_WRITE |
+                                      SND_SEQ_PORT_CAP_SUBS_WRITE );
     snd_seq_port_info_set_type( pinfo,
-				SND_SEQ_PORT_TYPE_MIDI_GENERIC |
-				SND_SEQ_PORT_TYPE_APPLICATION );
-    snd_seq_port_info_set_midi_channels(pinfo, 16);
+                                SND_SEQ_PORT_TYPE_MIDI_GENERIC |
+                                SND_SEQ_PORT_TYPE_APPLICATION );
+    snd_seq_port_info_set_midi_channels( pinfo, 16 );
 #ifndef AVOID_TIMESTAMPING
-    snd_seq_port_info_set_timestamping(pinfo, 1);
-    snd_seq_port_info_set_timestamp_real(pinfo, 1);    
-    snd_seq_port_info_set_timestamp_queue(pinfo, data->queue_id);
+    snd_seq_port_info_set_timestamping( pinfo, 1 );
+    snd_seq_port_info_set_timestamp_real( pinfo, 1 );
+    snd_seq_port_info_set_timestamp_queue( pinfo, data->queue_id );
 #endif
-    snd_seq_port_info_set_name(pinfo, portName.c_str());
-    data->vport = snd_seq_create_port(data->seq, pinfo);
+    snd_seq_port_info_set_name( pinfo, portName.c_str() );
+    data->vport = snd_seq_create_port( data->seq, pinfo );
 
     if ( data->vport < 0 ) {
       errorString_ = "MidiInAlsa::openVirtualPort: ALSA error creating virtual port.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
     }
-    data->vport = snd_seq_port_info_get_port(pinfo);
+    data->vport = snd_seq_port_info_get_port( pinfo );
   }
 
   if ( inputData_.doInput == false ) {
     // Wait for old thread to stop, if still running
-    if ( !pthread_equal(data->thread, data->dummy_thread_id) )
+    if ( !pthread_equal( data->thread, data->dummy_thread_id ) )
       pthread_join( data->thread, NULL );
 
     // Start the input queue
@@ -1608,13 +2012,13 @@ void MidiInAlsa :: openVirtualPort( std::string portName )
 #endif
     // Start our MIDI input thread.
     pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-    pthread_attr_setschedpolicy(&attr, SCHED_OTHER);
+    pthread_attr_init( &attr );
+    pthread_attr_setdetachstate( &attr, PTHREAD_CREATE_JOINABLE );
+    pthread_attr_setschedpolicy( &attr, SCHED_OTHER );
 
     inputData_.doInput = true;
-    int err = pthread_create(&data->thread, &attr, alsaMidiHandler, &inputData_);
-    pthread_attr_destroy(&attr);
+    int err = pthread_create( &data->thread, &attr, alsaMidiHandler, &inputData_ );
+    pthread_attr_destroy( &attr );
     if ( err ) {
       if ( data->subscription ) {
         snd_seq_unsubscribe_port( data->seq, data->subscription );
@@ -1650,11 +2054,29 @@ void MidiInAlsa :: closePort( void )
   // Stop thread to avoid triggering the callback, while the port is intended to be closed
   if ( inputData_.doInput ) {
     inputData_.doInput = false;
-    int res = write( data->trigger_fds[1], &inputData_.doInput, sizeof(inputData_.doInput) );
+    int res = write( data->trigger_fds[1], &inputData_.doInput, sizeof( inputData_.doInput ) );
     (void) res;
-    if ( !pthread_equal(data->thread, data->dummy_thread_id) )
+    if ( !pthread_equal( data->thread, data->dummy_thread_id ) )
       pthread_join( data->thread, NULL );
   }
+}
+
+void MidiInAlsa :: setClientName( const std::string &clientName )
+{
+
+  AlsaMidiData *data = static_cast<AlsaMidiData *> ( apiData_ );
+  snd_seq_set_client_name( data->seq, clientName.c_str() );
+
+}
+
+void MidiInAlsa :: setPortName( const std::string &portName )
+{
+  AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
+  snd_seq_port_info_t *pinfo;
+  snd_seq_port_info_alloca( &pinfo );
+  snd_seq_get_port_info( data->seq, data->vport, pinfo );
+  snd_seq_port_info_set_name( pinfo, portName.c_str() );
+  snd_seq_set_port_info( data->seq, data->vport, pinfo );
 }
 
 //*********************************************************************//
@@ -1662,15 +2084,15 @@ void MidiInAlsa :: closePort( void )
 //  Class Definitions: MidiOutAlsa
 //*********************************************************************//
 
-MidiOutAlsa :: MidiOutAlsa( const std::string clientName ) : MidiOutApi()
+MidiOutAlsa :: MidiOutAlsa( const std::string &clientName ) : MidiOutApi()
 {
-  initialize( clientName );
+  MidiOutAlsa::initialize( clientName );
 }
 
 MidiOutAlsa :: ~MidiOutAlsa()
 {
   // Close a connection if it exists.
-  closePort();
+  MidiOutAlsa::closePort();
 
   // Cleanup.
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
@@ -1690,7 +2112,7 @@ void MidiOutAlsa :: initialize( const std::string& clientName )
     errorString_ = "MidiOutAlsa::initialize: error creating ALSA sequencer client object.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
-	}
+  }
 
   // Set client name.
   snd_seq_set_client_name( seq, clientName.c_str() );
@@ -1723,8 +2145,8 @@ void MidiOutAlsa :: initialize( const std::string& clientName )
 
 unsigned int MidiOutAlsa :: getPortCount()
 {
-	snd_seq_port_info_t *pinfo;
-	snd_seq_port_info_alloca( &pinfo );
+  snd_seq_port_info_t *pinfo;
+  snd_seq_port_info_alloca( &pinfo );
 
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   return portInfo( data->seq, pinfo, SND_SEQ_PORT_CAP_WRITE|SND_SEQ_PORT_CAP_SUBS_WRITE, -1 );
@@ -1740,14 +2162,16 @@ std::string MidiOutAlsa :: getPortName( unsigned int portNumber )
   std::string stringName;
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( portInfo( data->seq, pinfo, SND_SEQ_PORT_CAP_WRITE|SND_SEQ_PORT_CAP_SUBS_WRITE, (int) portNumber ) ) {
-    int cnum = snd_seq_port_info_get_client(pinfo);
+    int cnum = snd_seq_port_info_get_client( pinfo );
     snd_seq_get_any_client_info( data->seq, cnum, cinfo );
     std::ostringstream os;
-    os << snd_seq_client_info_get_name(cinfo);
+    os << snd_seq_client_info_get_name( cinfo );
+    os << ":";
+    os << snd_seq_port_info_get_name( pinfo );
     os << " ";                                    // These lines added to make sure devices are listed
     os << snd_seq_port_info_get_client( pinfo );  // with full portnames added to ensure individual device names
     os << ":";
-    os << snd_seq_port_info_get_port(pinfo);
+    os << snd_seq_port_info_get_port( pinfo );
     stringName = os.str();
     return stringName;
   }
@@ -1758,7 +2182,7 @@ std::string MidiOutAlsa :: getPortName( unsigned int portNumber )
   return stringName;
 }
 
-void MidiOutAlsa :: openPort( unsigned int portNumber, const std::string portName )
+void MidiOutAlsa :: openPort( unsigned int portNumber, const std::string &portName )
 {
   if ( connected_ ) {
     errorString_ = "MidiOutAlsa::openPort: a valid connection already exists!";
@@ -1767,14 +2191,14 @@ void MidiOutAlsa :: openPort( unsigned int portNumber, const std::string portNam
   }
 
   unsigned int nSrc = this->getPortCount();
-  if (nSrc < 1) {
+  if ( nSrc < 1 ) {
     errorString_ = "MidiOutAlsa::openPort: no MIDI output sources found!";
     error( RtMidiError::NO_DEVICES_FOUND, errorString_ );
     return;
   }
 
-	snd_seq_port_info_t *pinfo;
-	snd_seq_port_info_alloca( &pinfo );
+  snd_seq_port_info_t *pinfo;
+  snd_seq_port_info_alloca( &pinfo );
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( portInfo( data->seq, pinfo, SND_SEQ_PORT_CAP_WRITE|SND_SEQ_PORT_CAP_SUBS_WRITE, (int) portNumber ) == 0 ) {
     std::ostringstream ost;
@@ -1803,17 +2227,17 @@ void MidiOutAlsa :: openPort( unsigned int portNumber, const std::string portNam
   sender.port = data->vport;
 
   // Make subscription
-  if (snd_seq_port_subscribe_malloc( &data->subscription ) < 0) {
+  if ( snd_seq_port_subscribe_malloc( &data->subscription ) < 0 ) {
     snd_seq_port_subscribe_free( data->subscription );
     errorString_ = "MidiOutAlsa::openPort: error allocating port subscription.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
   }
-  snd_seq_port_subscribe_set_sender(data->subscription, &sender);
-  snd_seq_port_subscribe_set_dest(data->subscription, &receiver);
-  snd_seq_port_subscribe_set_time_update(data->subscription, 1);
-  snd_seq_port_subscribe_set_time_real(data->subscription, 1);
-  if ( snd_seq_subscribe_port(data->seq, data->subscription) ) {
+  snd_seq_port_subscribe_set_sender( data->subscription, &sender );
+  snd_seq_port_subscribe_set_dest( data->subscription, &receiver );
+  snd_seq_port_subscribe_set_time_update( data->subscription, 1 );
+  snd_seq_port_subscribe_set_time_real( data->subscription, 1 );
+  if ( snd_seq_subscribe_port( data->seq, data->subscription ) ) {
     snd_seq_port_subscribe_free( data->subscription );
     errorString_ = "MidiOutAlsa::openPort: ALSA error making port connection.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -1829,11 +2253,30 @@ void MidiOutAlsa :: closePort( void )
     AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
     snd_seq_unsubscribe_port( data->seq, data->subscription );
     snd_seq_port_subscribe_free( data->subscription );
+    data->subscription = 0;
     connected_ = false;
   }
 }
 
-void MidiOutAlsa :: openVirtualPort( std::string portName )
+void MidiOutAlsa :: setClientName( const std::string &clientName )
+{
+
+    AlsaMidiData *data = static_cast<AlsaMidiData *> ( apiData_ );
+    snd_seq_set_client_name( data->seq, clientName.c_str() );
+
+}
+
+void MidiOutAlsa :: setPortName( const std::string &portName )
+{
+  AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
+  snd_seq_port_info_t *pinfo;
+  snd_seq_port_info_alloca( &pinfo );
+  snd_seq_get_port_info( data->seq, data->vport, pinfo );
+  snd_seq_port_info_set_name( pinfo, portName.c_str() );
+  snd_seq_set_port_info( data->seq, data->vport, pinfo );
+}
+
+void MidiOutAlsa :: openVirtualPort( const std::string &portName )
 {
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
   if ( data->vport < 0 ) {
@@ -1848,14 +2291,14 @@ void MidiOutAlsa :: openVirtualPort( std::string portName )
   }
 }
 
-void MidiOutAlsa :: sendMessage( std::vector<unsigned char> *message )
+void MidiOutAlsa :: sendMessage( const unsigned char *message, size_t size )
 {
   int result;
   AlsaMidiData *data = static_cast<AlsaMidiData *> (apiData_);
-  unsigned int nBytes = message->size();
+  unsigned int nBytes = static_cast<unsigned int> (size);
   if ( nBytes > data->bufferSize ) {
     data->bufferSize = nBytes;
-    result = snd_midi_event_resize_buffer ( data->coder, nBytes);
+    result = snd_midi_event_resize_buffer( data->coder, nBytes );
     if ( result != 0 ) {
       errorString_ = "MidiOutAlsa::sendMessage: ALSA error resizing MIDI event buffer.";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
@@ -1864,18 +2307,18 @@ void MidiOutAlsa :: sendMessage( std::vector<unsigned char> *message )
     free (data->buffer);
     data->buffer = (unsigned char *) malloc( data->bufferSize );
     if ( data->buffer == NULL ) {
-    errorString_ = "MidiOutAlsa::initialize: error allocating buffer memory!\n\n";
-    error( RtMidiError::MEMORY_ERROR, errorString_ );
-    return;
+      errorString_ = "MidiOutAlsa::initialize: error allocating buffer memory!\n\n";
+      error( RtMidiError::MEMORY_ERROR, errorString_ );
+      return;
     }
   }
 
   snd_seq_event_t ev;
-  snd_seq_ev_clear(&ev);
-  snd_seq_ev_set_source(&ev, data->vport);
-  snd_seq_ev_set_subs(&ev);
-  snd_seq_ev_set_direct(&ev);
-  for ( unsigned int i=0; i<nBytes; ++i ) data->buffer[i] = message->at(i);
+  snd_seq_ev_clear( &ev );
+  snd_seq_ev_set_source( &ev, data->vport );
+  snd_seq_ev_set_subs( &ev );
+  snd_seq_ev_set_direct( &ev );
+  for ( unsigned int i=0; i<nBytes; ++i ) data->buffer[i] = message[i];
   result = snd_midi_event_encode( data->coder, data->buffer, (long)nBytes, &ev );
   if ( result < (int)nBytes ) {
     errorString_ = "MidiOutAlsa::sendMessage: event parsing error!";
@@ -1884,13 +2327,13 @@ void MidiOutAlsa :: sendMessage( std::vector<unsigned char> *message )
   }
 
   // Send the event.
-  result = snd_seq_event_output(data->seq, &ev);
+  result = snd_seq_event_output( data->seq, &ev );
   if ( result < 0 ) {
     errorString_ = "MidiOutAlsa::sendMessage: error sending MIDI message to port.";
     error( RtMidiError::WARNING, errorString_ );
     return;
   }
-  snd_seq_drain_output(data->seq);
+  snd_seq_drain_output( data->seq );
 }
 
 #endif // __LINUX_ALSA__
@@ -1915,6 +2358,34 @@ void MidiOutAlsa :: sendMessage( std::vector<unsigned char> *message )
 #include <windows.h>
 #include <mmsystem.h>
 
+// Convert a null-terminated wide string or ANSI-encoded string to UTF-8.
+static std::string ConvertToUTF8(const TCHAR *str)
+{
+  std::string u8str;
+  const WCHAR *wstr = L"";
+#if defined( UNICODE ) || defined( _UNICODE )
+  wstr = str;
+#else
+  // Convert from ANSI encoding to wide string
+  int wlength = MultiByteToWideChar( CP_ACP, 0, str, -1, NULL, 0 );
+  std::wstring wstrtemp;
+  if ( wlength )
+  {
+    wstrtemp.assign( wlength - 1, 0 );
+    MultiByteToWideChar( CP_ACP, 0, str, -1, &wstrtemp[0], wlength );
+    wstr = &wstrtemp[0];
+  }
+#endif
+  // Convert from wide string to UTF-8
+  int length = WideCharToMultiByte( CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL );
+  if ( length )
+  {
+    u8str.assign( length - 1, 0 );
+    length = WideCharToMultiByte( CP_UTF8, 0, wstr, -1, &u8str[0], length, NULL, NULL );
+  }
+  return u8str;
+}
+
 #define  RT_SYSEX_BUFFER_SIZE 1024
 #define  RT_SYSEX_BUFFER_COUNT 4
 
@@ -1935,7 +2406,7 @@ struct WinMidiData {
 //*********************************************************************//
 
 static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
-                                        UINT inputStatus, 
+                                        UINT inputStatus,
                                         DWORD_PTR instancePtr,
                                         DWORD_PTR midiMessage,
                                         DWORD timestamp )
@@ -1952,7 +2423,6 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
     data->firstMessage = false;
   }
   else apiData->message.timeStamp = (double) ( timestamp - apiData->lastTime ) * 0.001;
-  apiData->lastTime = timestamp;
 
   if ( inputStatus == MIM_DATA ) { // Channel or system message
 
@@ -1971,11 +2441,11 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
     }
     else if ( status == 0xF2 ) nBytes = 3;
     else if ( status == 0xF3 ) nBytes = 2;
-    else if ( status == 0xF8 && (data->ignoreFlags & 0x02) ) {
+    else if ( status == 0xF8 && ( data->ignoreFlags & 0x02 ) ) {
       // A MIDI timing tick message and we're ignoring it.
       return;
     }
-    else if ( status == 0xFE && (data->ignoreFlags & 0x04) ) {
+    else if ( status == 0xFE && ( data->ignoreFlags & 0x04 ) ) {
       // A MIDI active sensing message and we're ignoring it.
       return;
     }
@@ -1985,8 +2455,8 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
     for ( int i=0; i<nBytes; ++i ) apiData->message.bytes.push_back( *ptr++ );
   }
   else { // Sysex message ( MIM_LONGDATA or MIM_LONGERROR )
-    MIDIHDR *sysex = ( MIDIHDR *) midiMessage; 
-    if ( !( data->ignoreFlags & 0x01 ) && inputStatus != MIM_LONGERROR ) {  
+    MIDIHDR *sysex = ( MIDIHDR *) midiMessage;
+    if ( !( data->ignoreFlags & 0x01 ) && inputStatus != MIM_LONGERROR ) {
       // Sysex message and we're not ignoring it
       for ( int i=0; i<(int)sysex->dwBytesRecorded; ++i )
         apiData->message.bytes.push_back( sysex->lpData[i] );
@@ -2013,35 +2483,33 @@ static void CALLBACK midiInputCallback( HMIDIIN /*hmin*/,
     else return;
   }
 
+  // Save the time of the last non-filtered message
+  apiData->lastTime = timestamp;
+
   if ( data->usingCallback ) {
     RtMidiIn::RtMidiCallback callback = (RtMidiIn::RtMidiCallback) data->userCallback;
     callback( apiData->message.timeStamp, &apiData->message.bytes, data->userData );
   }
   else {
     // As long as we haven't reached our queue size limit, push the message.
-    if ( data->queue.size < data->queue.ringSize ) {
-      data->queue.ring[data->queue.back++] = apiData->message;
-      if ( data->queue.back == data->queue.ringSize )
-        data->queue.back = 0;
-      data->queue.size++;
-    }
-    else
-      std::cerr << "\nRtMidiIn: message queue limit reached!!\n\n";
+    if ( !data->queue.push( apiData->message ) )
+      std::cerr << "\nMidiInWinMM: message queue limit reached!!\n\n";
   }
 
   // Clear the vector for the next input message.
   apiData->message.bytes.clear();
 }
 
-MidiInWinMM :: MidiInWinMM( const std::string clientName, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit )
+MidiInWinMM :: MidiInWinMM( const std::string &clientName, unsigned int queueSizeLimit )
+  : MidiInApi( queueSizeLimit )
 {
-  initialize( clientName );
+  MidiInWinMM::initialize( clientName );
 }
 
 MidiInWinMM :: ~MidiInWinMM()
 {
   // Close a connection if it exists.
-  closePort();
+  MidiInWinMM::closePort();
 
   WinMidiData *data = static_cast<WinMidiData *> (apiData_);
   DeleteCriticalSection( &(data->_mutex) );
@@ -2066,13 +2534,13 @@ void MidiInWinMM :: initialize( const std::string& /*clientName*/ )
   inputData_.apiData = (void *) data;
   data->message.bytes.clear();  // needs to be empty for first input message
 
-  if ( !InitializeCriticalSectionAndSpinCount(&(data->_mutex), 0x00000400) ) {
+  if ( !InitializeCriticalSectionAndSpinCount( &(data->_mutex), 0x00000400 ) ) {
     errorString_ = "MidiInWinMM::initialize: InitializeCriticalSectionAndSpinCount failed.";
     error( RtMidiError::WARNING, errorString_ );
   }
 }
 
-void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portName*/ )
+void MidiInWinMM :: openPort( unsigned int portNumber, const std::string &/*portName*/ )
 {
   if ( connected_ ) {
     errorString_ = "MidiInWinMM::openPort: a valid connection already exists!";
@@ -2118,6 +2586,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portN
     result = midiInPrepareHeader( data->inHandle, data->sysexBuffer[i], sizeof(MIDIHDR) );
     if ( result != MMSYSERR_NOERROR ) {
       midiInClose( data->inHandle );
+      data->inHandle = 0;
       errorString_ = "MidiInWinMM::openPort: error starting Windows MM MIDI input port (PrepareHeader).";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
@@ -2127,6 +2596,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portN
     result = midiInAddBuffer( data->inHandle, data->sysexBuffer[i], sizeof(MIDIHDR) );
     if ( result != MMSYSERR_NOERROR ) {
       midiInClose( data->inHandle );
+      data->inHandle = 0;
       errorString_ = "MidiInWinMM::openPort: error starting Windows MM MIDI input port (AddBuffer).";
       error( RtMidiError::DRIVER_ERROR, errorString_ );
       return;
@@ -2136,6 +2606,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portN
   result = midiInStart( data->inHandle );
   if ( result != MMSYSERR_NOERROR ) {
     midiInClose( data->inHandle );
+    data->inHandle = 0;
     errorString_ = "MidiInWinMM::openPort: error starting Windows MM MIDI input port.";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
@@ -2144,7 +2615,7 @@ void MidiInWinMM :: openPort( unsigned int portNumber, const std::string /*portN
   connected_ = true;
 }
 
-void MidiInWinMM :: openVirtualPort( std::string /*portName*/ )
+void MidiInWinMM :: openVirtualPort( const std::string &/*portName*/ )
 {
   // This function cannot be implemented for the Windows MM MIDI API.
   errorString_ = "MidiInWinMM::openVirtualPort: cannot be implemented in Windows MM MIDI API!";
@@ -2165,6 +2636,7 @@ void MidiInWinMM :: closePort( void )
       delete [] data->sysexBuffer[i];
       if ( result != MMSYSERR_NOERROR ) {
         midiInClose( data->inHandle );
+        data->inHandle = 0;
         errorString_ = "MidiInWinMM::openPort: error closing Windows MM MIDI input port (midiInUnprepareHeader).";
         error( RtMidiError::DRIVER_ERROR, errorString_ );
         return;
@@ -2172,9 +2644,26 @@ void MidiInWinMM :: closePort( void )
     }
 
     midiInClose( data->inHandle );
+    data->inHandle = 0;
     connected_ = false;
     LeaveCriticalSection( &(data->_mutex) );
   }
+}
+
+void MidiInWinMM :: setClientName ( const std::string& )
+{
+
+  errorString_ = "MidiInWinMM::setClientName: this function is not implemented for the WINDOWS_MM API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiInWinMM :: setPortName ( const std::string& )
+{
+
+  errorString_ = "MidiInWinMM::setPortName: this function is not implemented for the WINDOWS_MM API!";
+  error( RtMidiError::WARNING, errorString_ );
+
 }
 
 unsigned int MidiInWinMM :: getPortCount()
@@ -2196,22 +2685,17 @@ std::string MidiInWinMM :: getPortName( unsigned int portNumber )
 
   MIDIINCAPS deviceCaps;
   midiInGetDevCaps( portNumber, &deviceCaps, sizeof(MIDIINCAPS));
+  stringName = ConvertToUTF8( deviceCaps.szPname );
 
-#if defined( UNICODE ) || defined( _UNICODE )
-  int length = WideCharToMultiByte(CP_UTF8, 0, deviceCaps.szPname, -1, NULL, 0, NULL, NULL) - 1;
-  stringName.assign( length, 0 );
-  length = WideCharToMultiByte(CP_UTF8, 0, deviceCaps.szPname, static_cast<int>(wcslen(deviceCaps.szPname)), &stringName[0], length, NULL, NULL);
-#else
-  stringName = std::string( deviceCaps.szPname );
-#endif
-
-  // Next lines added to add the portNumber to the name so that 
+  // Next lines added to add the portNumber to the name so that
   // the device's names are sure to be listed with individual names
   // even when they have the same brand name
+#ifndef RTMIDI_DO_NOT_ENSURE_UNIQUE_PORTNAMES
   std::ostringstream os;
   os << " ";
   os << portNumber;
   stringName += os.str();
+#endif
 
   return stringName;
 }
@@ -2221,15 +2705,15 @@ std::string MidiInWinMM :: getPortName( unsigned int portNumber )
 //  Class Definitions: MidiOutWinMM
 //*********************************************************************//
 
-MidiOutWinMM :: MidiOutWinMM( const std::string clientName ) : MidiOutApi()
+MidiOutWinMM :: MidiOutWinMM( const std::string &clientName ) : MidiOutApi()
 {
-  initialize( clientName );
+  MidiOutWinMM::initialize( clientName );
 }
 
 MidiOutWinMM :: ~MidiOutWinMM()
 {
   // Close a connection if it exists.
-  closePort();
+  MidiOutWinMM::closePort();
 
   // Cleanup.
   WinMidiData *data = static_cast<WinMidiData *> (apiData_);
@@ -2269,28 +2753,23 @@ std::string MidiOutWinMM :: getPortName( unsigned int portNumber )
   }
 
   MIDIOUTCAPS deviceCaps;
-  midiOutGetDevCaps( portNumber, &deviceCaps, sizeof(MIDIOUTCAPS));
+  midiOutGetDevCaps( portNumber, &deviceCaps, sizeof( MIDIOUTCAPS ) );
+  stringName = ConvertToUTF8( deviceCaps.szPname );
 
-#if defined( UNICODE ) || defined( _UNICODE )
-  int length = WideCharToMultiByte(CP_UTF8, 0, deviceCaps.szPname, -1, NULL, 0, NULL, NULL) - 1;
-  stringName.assign( length, 0 );
-  length = WideCharToMultiByte(CP_UTF8, 0, deviceCaps.szPname, static_cast<int>(wcslen(deviceCaps.szPname)), &stringName[0], length, NULL, NULL);
-#else
-  stringName = std::string( deviceCaps.szPname );
-#endif
-
-  // Next lines added to add the portNumber to the name so that 
+  // Next lines added to add the portNumber to the name so that
   // the device's names are sure to be listed with individual names
   // even when they have the same brand name
   std::ostringstream os;
+#ifndef RTMIDI_DO_NOT_ENSURE_UNIQUE_PORTNAMES
   os << " ";
   os << portNumber;
   stringName += os.str();
+#endif
 
   return stringName;
 }
 
-void MidiOutWinMM :: openPort( unsigned int portNumber, const std::string /*portName*/ )
+void MidiOutWinMM :: openPort( unsigned int portNumber, const std::string &/*portName*/ )
 {
   if ( connected_ ) {
     errorString_ = "MidiOutWinMM::openPort: a valid connection already exists!";
@@ -2299,7 +2778,7 @@ void MidiOutWinMM :: openPort( unsigned int portNumber, const std::string /*port
   }
 
   unsigned int nDevices = midiOutGetNumDevs();
-  if (nDevices < 1) {
+  if ( nDevices < 1 ) {
     errorString_ = "MidiOutWinMM::openPort: no MIDI output destinations found!";
     error( RtMidiError::NO_DEVICES_FOUND, errorString_ );
     return;
@@ -2334,22 +2813,39 @@ void MidiOutWinMM :: closePort( void )
     WinMidiData *data = static_cast<WinMidiData *> (apiData_);
     midiOutReset( data->outHandle );
     midiOutClose( data->outHandle );
+    data->outHandle = 0;
     connected_ = false;
   }
 }
 
-void MidiOutWinMM :: openVirtualPort( std::string /*portName*/ )
+void MidiOutWinMM :: setClientName ( const std::string& )
+{
+
+  errorString_ = "MidiOutWinMM::setClientName: this function is not implemented for the WINDOWS_MM API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiOutWinMM :: setPortName ( const std::string& )
+{
+
+  errorString_ = "MidiOutWinMM::setPortName: this function is not implemented for the WINDOWS_MM API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiOutWinMM :: openVirtualPort( const std::string &/*portName*/ )
 {
   // This function cannot be implemented for the Windows MM MIDI API.
   errorString_ = "MidiOutWinMM::openVirtualPort: cannot be implemented in Windows MM MIDI API!";
   error( RtMidiError::WARNING, errorString_ );
 }
 
-void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
+void MidiOutWinMM :: sendMessage( const unsigned char *message, size_t size )
 {
   if ( !connected_ ) return;
 
-  unsigned int nBytes = static_cast<unsigned int>(message->size());
+  unsigned int nBytes = static_cast<unsigned int>(size);
   if ( nBytes == 0 ) {
     errorString_ = "MidiOutWinMM::sendMessage: message argument is empty!";
     error( RtMidiError::WARNING, errorString_ );
@@ -2358,7 +2854,7 @@ void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
 
   MMRESULT result;
   WinMidiData *data = static_cast<WinMidiData *> (apiData_);
-  if ( message->at(0) == 0xF0 ) { // Sysex message
+  if ( message[0] == 0xF0 ) { // Sysex message
 
     // Allocate buffer for sysex data.
     char *buffer = (char *) malloc( nBytes );
@@ -2369,14 +2865,14 @@ void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
     }
 
     // Copy data to buffer.
-    for ( unsigned int i=0; i<nBytes; ++i ) buffer[i] = message->at(i);
+    for ( unsigned int i=0; i<nBytes; ++i ) buffer[i] = message[i];
 
     // Create and prepare MIDIHDR structure.
     MIDIHDR sysex;
     sysex.lpData = (LPSTR) buffer;
     sysex.dwBufferLength = nBytes;
     sysex.dwFlags = 0;
-    result = midiOutPrepareHeader( data->outHandle,  &sysex, sizeof(MIDIHDR) ); 
+    result = midiOutPrepareHeader( data->outHandle,  &sysex, sizeof( MIDIHDR ) );
     if ( result != MMSYSERR_NOERROR ) {
       free( buffer );
       errorString_ = "MidiOutWinMM::sendMessage: error preparing sysex header.";
@@ -2385,7 +2881,7 @@ void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
     }
 
     // Send the message.
-    result = midiOutLongMsg( data->outHandle, &sysex, sizeof(MIDIHDR) );
+    result = midiOutLongMsg( data->outHandle, &sysex, sizeof( MIDIHDR ) );
     if ( result != MMSYSERR_NOERROR ) {
       free( buffer );
       errorString_ = "MidiOutWinMM::sendMessage: error sending sysex message.";
@@ -2394,7 +2890,7 @@ void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
     }
 
     // Unprepare the buffer and MIDIHDR.
-    while ( MIDIERR_STILLPLAYING == midiOutUnprepareHeader( data->outHandle, &sysex, sizeof (MIDIHDR) ) ) Sleep( 1 );
+    while ( MIDIERR_STILLPLAYING == midiOutUnprepareHeader( data->outHandle, &sysex, sizeof ( MIDIHDR ) ) ) Sleep( 1 );
     free( buffer );
   }
   else { // Channel or system message.
@@ -2410,7 +2906,7 @@ void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
     DWORD packet;
     unsigned char *ptr = (unsigned char *) &packet;
     for ( unsigned int i=0; i<nBytes; ++i ) {
-      *ptr = message->at(i);
+      *ptr = message[i];
       ++ptr;
     }
 
@@ -2440,6 +2936,9 @@ void MidiOutWinMM :: sendMessage( std::vector<unsigned char> *message )
 #include <jack/jack.h>
 #include <jack/midiport.h>
 #include <jack/ringbuffer.h>
+#ifdef HAVE_SEMAPHORE
+  #include <semaphore.h>
+#endif
 
 #define JACK_RINGBUFFER_SIZE 16384 // Default size for ringbuffer
 
@@ -2449,6 +2948,10 @@ struct JackMidiData {
   jack_ringbuffer_t *buffSize;
   jack_ringbuffer_t *buffMessage;
   jack_time_t lastTime;
+#ifdef HAVE_SEMAPHORE
+  sem_t sem_cleanup;
+  sem_t sem_needpost;
+#endif
   MidiInApi :: RtMidiInData *rtMidiIn;
   };
 
@@ -2466,42 +2969,71 @@ static int jackProcessIn( jack_nframes_t nframes, void *arg )
 
   // Is port created?
   if ( jData->port == NULL ) return 0;
+
   void *buff = jack_port_get_buffer( jData->port, nframes );
+  bool& continueSysex = rtData->continueSysex;
+  unsigned char& ignoreFlags = rtData->ignoreFlags;
 
   // We have midi events in buffer
   int evCount = jack_midi_get_event_count( buff );
   for (int j = 0; j < evCount; j++) {
-    MidiInApi::MidiMessage message;
-    message.bytes.clear();
-
+    MidiInApi::MidiMessage& message = rtData->message;
     jack_midi_event_get( &event, buff, j );
-
-    for ( unsigned int i = 0; i < event.size; i++ )
-      message.bytes.push_back( event.buffer[i] );
 
     // Compute the delta time.
     time = jack_get_time();
-    if ( rtData->firstMessage == true )
+    if ( rtData->firstMessage == true ) {
+      message.timeStamp = 0.0;
       rtData->firstMessage = false;
-    else
+    } else
       message.timeStamp = ( time - jData->lastTime ) * 0.000001;
 
     jData->lastTime = time;
 
-    if ( !rtData->continueSysex ) {
+    if ( !continueSysex )
+      message.bytes.clear();
+
+    if ( !( ( continueSysex || event.buffer[0] == 0xF0 ) && ( ignoreFlags & 0x01 ) ) ) {
+      // Unless this is a (possibly continued) SysEx message and we're ignoring SysEx,
+      // copy the event buffer into the MIDI message struct.
+      for ( unsigned int i = 0; i < event.size; i++ )
+        message.bytes.push_back( event.buffer[i] );
+    }
+
+    switch ( event.buffer[0] ) {
+      case 0xF0:
+        // Start of a SysEx message
+        continueSysex = event.buffer[event.size - 1] != 0xF7;
+        if ( ignoreFlags & 0x01 ) continue;
+        break;
+      case 0xF1:
+      case 0xF8:
+        // MIDI Time Code or Timing Clock message
+        if ( ignoreFlags & 0x02 ) continue;
+        break;
+      case 0xFE:
+        // Active Sensing message
+        if ( ignoreFlags & 0x04 ) continue;
+        break;
+      default:
+        if ( continueSysex ) {
+          // Continuation of a SysEx message
+          continueSysex = event.buffer[event.size - 1] != 0xF7;
+          if ( ignoreFlags & 0x01 ) continue;
+        }
+        // All other MIDI messages
+    }
+
+    if ( !continueSysex ) {
+      // If not a continuation of a SysEx message,
+      // invoke the user callback function or queue the message.
       if ( rtData->usingCallback ) {
         RtMidiIn::RtMidiCallback callback = (RtMidiIn::RtMidiCallback) rtData->userCallback;
         callback( message.timeStamp, &message.bytes, rtData->userData );
       }
       else {
         // As long as we haven't reached our queue size limit, push the message.
-        if ( rtData->queue.size < rtData->queue.ringSize ) {
-          rtData->queue.ring[rtData->queue.back++] = message;
-          if ( rtData->queue.back == rtData->queue.ringSize )
-            rtData->queue.back = 0;
-          rtData->queue.size++;
-        }
-        else
+        if ( !rtData->queue.push( message ) )
           std::cerr << "\nMidiInJack: message queue limit reached!!\n\n";
       }
     }
@@ -2510,9 +3042,10 @@ static int jackProcessIn( jack_nframes_t nframes, void *arg )
   return 0;
 }
 
-MidiInJack :: MidiInJack( const std::string clientName, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit )
+MidiInJack :: MidiInJack( const std::string &clientName, unsigned int queueSizeLimit )
+  : MidiInApi( queueSizeLimit )
 {
-  initialize( clientName );
+  MidiInJack::initialize( clientName );
 }
 
 void MidiInJack :: initialize( const std::string& clientName )
@@ -2548,25 +3081,25 @@ void MidiInJack :: connect()
 MidiInJack :: ~MidiInJack()
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
-  closePort();
+  MidiInJack::closePort();
 
   if ( data->client )
     jack_client_close( data->client );
   delete data;
 }
 
-void MidiInJack :: openPort( unsigned int portNumber, const std::string portName )
+void MidiInJack :: openPort( unsigned int portNumber, const std::string &portName )
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
   connect();
 
   // Creating new port
-  if ( data->port == NULL)
+  if ( data->port == NULL )
     data->port = jack_port_register( data->client, portName.c_str(),
                                      JACK_DEFAULT_MIDI_TYPE, JackPortIsInput, 0 );
 
-  if ( data->port == NULL) {
+  if ( data->port == NULL ) {
     errorString_ = "MidiInJack::openPort: JACK error creating port";
     error( RtMidiError::DRIVER_ERROR, errorString_ );
     return;
@@ -2575,9 +3108,11 @@ void MidiInJack :: openPort( unsigned int portNumber, const std::string portName
   // Connecting to the output
   std::string name = getPortName( portNumber );
   jack_connect( data->client, name.c_str(), jack_port_name( data->port ) );
+
+  connected_ = true;
 }
 
-void MidiInJack :: openVirtualPort( const std::string portName )
+void MidiInJack :: openVirtualPort( const std::string &portName )
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
@@ -2615,7 +3150,7 @@ unsigned int MidiInJack :: getPortCount()
 std::string MidiInJack :: getPortName( unsigned int portNumber )
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
-  std::string retStr("");
+  std::string retStr( "" );
 
   connect();
 
@@ -2630,7 +3165,9 @@ std::string MidiInJack :: getPortName( unsigned int portNumber )
     return retStr;
   }
 
-  if ( ports[portNumber] == NULL ) {
+  unsigned int i;
+  for ( i=0; i<portNumber && ports[i]; i++ ) {}
+  if ( i < portNumber || !ports[portNumber] ) {
     std::ostringstream ost;
     ost << "MidiInJack::getPortName: the 'portNumber' argument (" << portNumber << ") is invalid.";
     errorString_ = ost.str();
@@ -2638,7 +3175,7 @@ std::string MidiInJack :: getPortName( unsigned int portNumber )
   }
   else retStr.assign( ports[portNumber] );
 
-  free( ports );
+  jack_free( ports );
   return retStr;
 }
 
@@ -2649,6 +3186,26 @@ void MidiInJack :: closePort()
   if ( data->port == NULL ) return;
   jack_port_unregister( data->client, data->port );
   data->port = NULL;
+
+  connected_ = false;
+}
+
+void MidiInJack:: setClientName( const std::string& )
+{
+
+  errorString_ = "MidiInJack::setClientName: this function is not implemented for the UNIX_JACK API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiInJack :: setPortName( const std::string &portName )
+{
+  JackMidiData *data = static_cast<JackMidiData *> (apiData_);
+#ifdef JACK_HAS_PORT_RENAME
+  jack_port_rename( data->client, data->port, portName.c_str() );
+#else
+  jack_port_set_name( data->port, portName.c_str() );
+#endif
 }
 
 //*********************************************************************//
@@ -2670,18 +3227,23 @@ static int jackProcessOut( jack_nframes_t nframes, void *arg )
   jack_midi_clear_buffer( buff );
 
   while ( jack_ringbuffer_read_space( data->buffSize ) > 0 ) {
-    jack_ringbuffer_read( data->buffSize, (char *) &space, (size_t) sizeof(space) );
+    jack_ringbuffer_read( data->buffSize, (char *) &space, (size_t) sizeof( space ) );
     midiData = jack_midi_event_reserve( buff, 0, space );
 
     jack_ringbuffer_read( data->buffMessage, (char *) midiData, (size_t) space );
   }
 
+#ifdef HAVE_SEMAPHORE
+  if ( !sem_trywait( &data->sem_needpost ) )
+    sem_post( &data->sem_cleanup );
+#endif
+
   return 0;
 }
 
-MidiOutJack :: MidiOutJack( const std::string clientName ) : MidiOutApi()
+MidiOutJack :: MidiOutJack( const std::string &clientName ) : MidiOutApi()
 {
-  initialize( clientName );
+  MidiOutJack::initialize( clientName );
 }
 
 void MidiOutJack :: initialize( const std::string& clientName )
@@ -2691,6 +3253,10 @@ void MidiOutJack :: initialize( const std::string& clientName )
 
   data->port = NULL;
   data->client = NULL;
+#ifdef HAVE_SEMAPHORE
+  sem_init( &data->sem_cleanup, 0, 0 );
+  sem_init( &data->sem_needpost, 0, 0 );
+#endif
   this->clientName = clientName;
 
   connect();
@@ -2701,13 +3267,13 @@ void MidiOutJack :: connect()
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
   if ( data->client )
     return;
-  
-  // Initialize output ringbuffers  
+
+  // Initialize output ringbuffers
   data->buffSize = jack_ringbuffer_create( JACK_RINGBUFFER_SIZE );
   data->buffMessage = jack_ringbuffer_create( JACK_RINGBUFFER_SIZE );
 
   // Initialize JACK client
-  if (( data->client = jack_client_open( clientName.c_str(), JackNoStartServer, NULL )) == 0) {
+  if ( ( data->client = jack_client_open( clientName.c_str(), JackNoStartServer, NULL ) ) == 0 ) {
     errorString_ = "MidiOutJack::initialize: JACK server not running?";
     error( RtMidiError::WARNING, errorString_ );
     return;
@@ -2720,8 +3286,8 @@ void MidiOutJack :: connect()
 MidiOutJack :: ~MidiOutJack()
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
-  closePort();
-  
+  MidiOutJack::closePort();
+
   // Cleanup
   jack_ringbuffer_free( data->buffSize );
   jack_ringbuffer_free( data->buffMessage );
@@ -2729,10 +3295,15 @@ MidiOutJack :: ~MidiOutJack()
     jack_client_close( data->client );
   }
 
+#ifdef HAVE_SEMAPHORE
+  sem_destroy( &data->sem_cleanup );
+  sem_destroy( &data->sem_needpost );
+#endif
+
   delete data;
 }
 
-void MidiOutJack :: openPort( unsigned int portNumber, const std::string portName )
+void MidiOutJack :: openPort( unsigned int portNumber, const std::string &portName )
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
@@ -2741,7 +3312,7 @@ void MidiOutJack :: openPort( unsigned int portNumber, const std::string portNam
   // Creating new port
   if ( data->port == NULL )
     data->port = jack_port_register( data->client, portName.c_str(),
-      JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0 );
+                                     JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0 );
 
   if ( data->port == NULL ) {
     errorString_ = "MidiOutJack::openPort: JACK error creating port";
@@ -2752,16 +3323,18 @@ void MidiOutJack :: openPort( unsigned int portNumber, const std::string portNam
   // Connecting to the output
   std::string name = getPortName( portNumber );
   jack_connect( data->client, jack_port_name( data->port ), name.c_str() );
+
+  connected_ = true;
 }
 
-void MidiOutJack :: openVirtualPort( const std::string portName )
+void MidiOutJack :: openVirtualPort( const std::string &portName )
 {
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
   connect();
   if ( data->port == NULL )
     data->port = jack_port_register( data->client, portName.c_str(),
-      JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0 );
+                                     JACK_DEFAULT_MIDI_TYPE, JackPortIsOutput, 0 );
 
   if ( data->port == NULL ) {
     errorString_ = "MidiOutJack::openVirtualPort: JACK error creating virtual port";
@@ -2779,7 +3352,7 @@ unsigned int MidiOutJack :: getPortCount()
 
   // List of available ports
   const char **ports = jack_get_ports( data->client, NULL,
-    JACK_DEFAULT_MIDI_TYPE, JackPortIsInput );
+                                       JACK_DEFAULT_MIDI_TYPE, JackPortIsInput );
 
   if ( ports == NULL ) return 0;
   while ( ports[count] != NULL )
@@ -2799,16 +3372,16 @@ std::string MidiOutJack :: getPortName( unsigned int portNumber )
 
   // List of available ports
   const char **ports = jack_get_ports( data->client, NULL,
-    JACK_DEFAULT_MIDI_TYPE, JackPortIsInput );
+                                       JACK_DEFAULT_MIDI_TYPE, JackPortIsInput );
 
   // Check port validity
-  if ( ports == NULL) {
+  if ( ports == NULL ) {
     errorString_ = "MidiOutJack::getPortName: no ports available!";
     error( RtMidiError::WARNING, errorString_ );
     return retStr;
   }
 
-  if ( ports[portNumber] == NULL) {
+  if ( ports[portNumber] == NULL ) {
     std::ostringstream ost;
     ost << "MidiOutJack::getPortName: the 'portNumber' argument (" << portNumber << ") is invalid.";
     errorString_ = ost.str();
@@ -2825,18 +3398,47 @@ void MidiOutJack :: closePort()
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
   if ( data->port == NULL ) return;
+
+#ifdef HAVE_SEMAPHORE
+  struct timespec ts;
+  if ( clock_gettime( CLOCK_REALTIME, &ts ) != -1 ) {
+    ts.tv_sec += 1; // wait max one second
+    sem_post( &data->sem_needpost );
+    sem_timedwait( &data->sem_cleanup, &ts );
+  }
+#endif
+
   jack_port_unregister( data->client, data->port );
   data->port = NULL;
+
+  connected_ = false;
 }
 
-void MidiOutJack :: sendMessage( std::vector<unsigned char> *message )
+void MidiOutJack:: setClientName( const std::string& )
 {
-  int nBytes = message->size();
+
+  errorString_ = "MidiOutJack::setClientName: this function is not implemented for the UNIX_JACK API!";
+  error( RtMidiError::WARNING, errorString_ );
+
+}
+
+void MidiOutJack :: setPortName( const std::string &portName )
+{
+  JackMidiData *data = static_cast<JackMidiData *> (apiData_);
+#ifdef JACK_HAS_PORT_RENAME
+  jack_port_rename( data->client, data->port, portName.c_str() );
+#else
+  jack_port_set_name( data->port, portName.c_str() );
+#endif
+}
+
+void MidiOutJack :: sendMessage( const unsigned char *message, size_t size )
+{
+  int nBytes = static_cast<int>(size);
   JackMidiData *data = static_cast<JackMidiData *> (apiData_);
 
   // Write full message to buffer
-  jack_ringbuffer_write( data->buffMessage, ( const char * ) &( *message )[0],
-                         message->size() );
+  jack_ringbuffer_write( data->buffMessage, ( const char * ) message, nBytes );
   jack_ringbuffer_write( data->buffSize, ( char * ) &nBytes, sizeof( nBytes ) );
 }
 

--- a/rtmidi/RtMidi.h
+++ b/rtmidi/RtMidi.h
@@ -5,10 +5,11 @@
     This class implements some common functionality for the realtime
     MIDI input/output subclasses RtMidiIn and RtMidiOut.
 
-    RtMidi WWW site: http://music.mcgill.ca/~gary/rtmidi/
+    RtMidi GitHub site: https://github.com/thestk/rtmidi
+    RtMidi WWW site: http://www.music.mcgill.ca/~gary/rtmidi/
 
     RtMidi: realtime MIDI i/o C++ classes
-    Copyright (c) 2003-2016 Gary P. Scavone
+    Copyright (c) 2003-2019 Gary P. Scavone
 
     Permission is hereby granted, free of charge, to any person
     obtaining a copy of this software and associated documentation files
@@ -43,7 +44,21 @@
 #ifndef RTMIDI_H
 #define RTMIDI_H
 
-#define RTMIDI_VERSION "2.1.1"
+#if defined _WIN32 || defined __CYGWIN__
+  #if defined(RTMIDI_EXPORT)
+    #define RTMIDI_DLL_PUBLIC __declspec(dllexport)
+  #else
+    #define RTMIDI_DLL_PUBLIC
+  #endif
+#else
+  #if __GNUC__ >= 4
+    #define RTMIDI_DLL_PUBLIC __attribute__( (visibility( "default" )) )
+  #else
+    #define RTMIDI_DLL_PUBLIC
+  #endif
+#endif
+
+#define RTMIDI_VERSION "4.0.0"
 
 #include <exception>
 #include <iostream>
@@ -60,7 +75,7 @@
 */
 /************************************************************************/
 
-class RtMidiError : public std::exception
+class RTMIDI_DLL_PUBLIC RtMidiError : public std::exception
 {
  public:
   //! Defined RtMidiError types.
@@ -79,8 +94,9 @@ class RtMidiError : public std::exception
   };
 
   //! The constructor.
-  RtMidiError( const std::string& message, Type type = RtMidiError::UNSPECIFIED ) throw() : message_(message), type_(type) {}
- 
+  RtMidiError( const std::string& message, Type type = RtMidiError::UNSPECIFIED ) throw()
+    : message_(message), type_(type) {}
+
   //! The destructor.
   virtual ~RtMidiError( void ) throw() {}
 
@@ -88,10 +104,10 @@ class RtMidiError : public std::exception
   virtual void printMessage( void ) const throw() { std::cerr << '\n' << message_ << "\n\n"; }
 
   //! Returns the thrown error message type.
-  virtual const Type& getType(void) const throw() { return type_; }
+  virtual const Type& getType( void ) const throw() { return type_; }
 
   //! Returns the thrown error message string.
-  virtual const std::string& getMessage(void) const throw() { return message_; }
+  virtual const std::string& getMessage( void ) const throw() { return message_; }
 
   //! Returns the thrown error message as a c-style string.
   virtual const char* what( void ) const throw() { return message_.c_str(); }
@@ -113,18 +129,18 @@ typedef void (*RtMidiErrorCallback)( RtMidiError::Type type, const std::string &
 
 class MidiApi;
 
-class RtMidi
+class RTMIDI_DLL_PUBLIC RtMidi
 {
  public:
-
   //! MIDI API specifier arguments.
   enum Api {
     UNSPECIFIED,    /*!< Search for a working compiled API. */
-    MACOSX_CORE,    /*!< Macintosh OS-X Core Midi API. */
+    MACOSX_CORE,    /*!< Macintosh OS-X CoreMIDI API. */
     LINUX_ALSA,     /*!< The Advanced Linux Sound Architecture API. */
     UNIX_JACK,      /*!< The JACK Low-Latency MIDI Server API. */
     WINDOWS_MM,     /*!< The Microsoft Multimedia MIDI API. */
-    RTMIDI_DUMMY    /*!< A compilable but non-functional API. */
+    RTMIDI_DUMMY,   /*!< A compilable but non-functional API. */
+    NUM_APIS        /*!< Number of values in this enum. */
   };
 
   //! A static function to determine the current RtMidi version.
@@ -138,11 +154,34 @@ class RtMidi
   */
   static void getCompiledApi( std::vector<RtMidi::Api> &apis ) throw();
 
+  //! Return the name of a specified compiled MIDI API.
+  /*!
+    This obtains a short lower-case name used for identification purposes.
+    This value is guaranteed to remain identical across library versions.
+    If the API is unknown, this function will return the empty string.
+  */
+  static std::string getApiName( RtMidi::Api api );
+
+  //! Return the display name of a specified compiled MIDI API.
+  /*!
+    This obtains a long name used for display purposes.
+    If the API is unknown, this function will return the empty string.
+  */
+  static std::string getApiDisplayName( RtMidi::Api api );
+
+  //! Return the compiled MIDI API having the given name.
+  /*!
+    A case insensitive comparison will check the specified name
+    against the list of compiled APIs, and return the one which
+    matches. On failure, the function returns UNSPECIFIED.
+  */
+  static RtMidi::Api getCompiledApiByName( const std::string &name );
+
   //! Pure virtual openPort() function.
-  virtual void openPort( unsigned int portNumber = 0, const std::string portName = std::string( "RtMidi" ) ) = 0;
+  virtual void openPort( unsigned int portNumber = 0, const std::string &portName = std::string( "RtMidi" ) ) = 0;
 
   //! Pure virtual openVirtualPort() function.
-  virtual void openVirtualPort( const std::string portName = std::string( "RtMidi" ) ) = 0;
+  virtual void openVirtualPort( const std::string &portName = std::string( "RtMidi" ) ) = 0;
 
   //! Pure virtual getPortCount() function.
   virtual unsigned int getPortCount() = 0;
@@ -153,7 +192,14 @@ class RtMidi
   //! Pure virtual closePort() function.
   virtual void closePort( void ) = 0;
 
+  void setClientName( const std::string &clientName );
+  void setPortName( const std::string &portName );
+
   //! Returns true if a port is open and false if not.
+  /*!
+      Note that this only applies to connections made with the openPort()
+      function, not to virtual ports.
+  */
   virtual bool isPortOpen( void ) const = 0;
 
   //! Set an error callback function to be invoked when an error has occured.
@@ -164,10 +210,8 @@ class RtMidi
   virtual void setErrorCallback( RtMidiErrorCallback errorCallback = NULL, void *userData = 0 ) = 0;
 
  protected:
-
   RtMidi();
   virtual ~RtMidi();
-
   MidiApi *rtapi_;
 };
 
@@ -185,7 +229,7 @@ class RtMidi
     possible to open a virtual input port to which other MIDI software
     clients can connect.
 
-    by Gary P. Scavone, 2003-2014.
+    by Gary P. Scavone, 2003-2017.
 */
 /**********************************************************************/
 
@@ -203,12 +247,12 @@ class RtMidi
 //
 // **************************************************************** //
 
-class RtMidiIn : public RtMidi
+class RTMIDI_DLL_PUBLIC RtMidiIn : public RtMidi
 {
  public:
 
   //! User callback function type definition.
-  typedef void (*RtMidiCallback)( double timeStamp, std::vector<unsigned char> *message, void *userData);
+  typedef void (*RtMidiCallback)( double timeStamp, std::vector<unsigned char> *message, void *userData );
 
   //! Default constructor that allows an optional api, client name and queue size.
   /*!
@@ -229,7 +273,7 @@ class RtMidiIn : public RtMidi
     \param queueSizeLimit An optional size of the MIDI input queue can be specified.
   */
   RtMidiIn( RtMidi::Api api=UNSPECIFIED,
-            const std::string clientName = std::string( "RtMidi Input Client"),
+            const std::string& clientName = "RtMidi Input Client",
             unsigned int queueSizeLimit = 100 );
 
   //! If a MIDI connection is still open, it will be closed by the destructor.
@@ -244,7 +288,7 @@ class RtMidiIn : public RtMidi
                       Otherwise, the default or first port found is opened.
     \param portName An optional name for the application port that is used to connect to portId can be specified.
   */
-  void openPort( unsigned int portNumber = 0, const std::string portName = std::string( "RtMidi Input" ) );
+  void openPort( unsigned int portNumber = 0, const std::string &portName = std::string( "RtMidi Input" ) );
 
   //! Create a virtual input port, with optional name, to allow software connections (OS X, JACK and ALSA only).
   /*!
@@ -256,7 +300,7 @@ class RtMidiIn : public RtMidi
     \param portName An optional name for the application port that is
                     used to connect to portId can be specified.
   */
-  void openVirtualPort( const std::string portName = std::string( "RtMidi Input" ) );
+  void openVirtualPort( const std::string &portName = std::string( "RtMidi Input" ) );
 
   //! Set a callback function to be invoked for incoming MIDI messages.
   /*!
@@ -282,6 +326,10 @@ class RtMidiIn : public RtMidi
   void closePort( void );
 
   //! Returns true if a port is open and false if not.
+  /*!
+      Note that this only applies to connections made with the openPort()
+      function, not to virtual ports.
+  */
   virtual bool isPortOpen() const;
 
   //! Return the number of available MIDI input ports.
@@ -293,7 +341,8 @@ class RtMidiIn : public RtMidi
   //! Return a string identifier for the specified MIDI input port number.
   /*!
     \return The name of the port with the given Id is returned.
-    \retval An empty string is returned if an invalid port specifier is provided.
+    \retval An empty string is returned if an invalid port specifier
+            is provided. User code should assume a UTF-8 encoding.
   */
   std::string getPortName( unsigned int portNumber = 0 );
 
@@ -325,8 +374,7 @@ class RtMidiIn : public RtMidi
   virtual void setErrorCallback( RtMidiErrorCallback errorCallback = NULL, void *userData = 0 );
 
  protected:
-  void openMidiApi( RtMidi::Api api, const std::string clientName, unsigned int queueSizeLimit );
-
+  void openMidiApi( RtMidi::Api api, const std::string &clientName, unsigned int queueSizeLimit );
 };
 
 /**********************************************************************/
@@ -341,14 +389,13 @@ class RtMidiIn : public RtMidi
     OS-X, Linux ALSA and JACK MIDI APIs, it is also possible to open a
     virtual port to which other MIDI software clients can connect.
 
-    by Gary P. Scavone, 2003-2014.
+    by Gary P. Scavone, 2003-2017.
 */
 /**********************************************************************/
 
-class RtMidiOut : public RtMidi
+class RTMIDI_DLL_PUBLIC RtMidiOut : public RtMidi
 {
  public:
-
   //! Default constructor that allows an optional client name.
   /*!
     An exception will be thrown if a MIDI system initialization error occurs.
@@ -358,7 +405,7 @@ class RtMidiOut : public RtMidi
     JACK (OS-X).
   */
   RtMidiOut( RtMidi::Api api=UNSPECIFIED,
-             const std::string clientName = std::string( "RtMidi Output Client") );
+             const std::string& clientName = "RtMidi Output Client" );
 
   //! The destructor closes any open MIDI connections.
   ~RtMidiOut( void ) throw();
@@ -373,12 +420,16 @@ class RtMidiOut : public RtMidi
       exception is thrown if an error occurs while attempting to make
       the port connection.
   */
-  void openPort( unsigned int portNumber = 0, const std::string portName = std::string( "RtMidi Output" ) );
+  void openPort( unsigned int portNumber = 0, const std::string &portName = std::string( "RtMidi Output" ) );
 
   //! Close an open MIDI connection (if one exists).
   void closePort( void );
 
   //! Returns true if a port is open and false if not.
+  /*!
+      Note that this only applies to connections made with the openPort()
+      function, not to virtual ports.
+  */
   virtual bool isPortOpen() const;
 
   //! Create a virtual output port, with optional name, to allow software connections (OS X, JACK and ALSA only).
@@ -390,14 +441,16 @@ class RtMidiOut : public RtMidi
       An exception is thrown if an error occurs while attempting to
       create the virtual port.
   */
-  void openVirtualPort( const std::string portName = std::string( "RtMidi Output" ) );
+  void openVirtualPort( const std::string &portName = std::string( "RtMidi Output" ) );
 
   //! Return the number of available MIDI output ports.
   unsigned int getPortCount( void );
 
   //! Return a string identifier for the specified MIDI port type and number.
   /*!
-      An empty string is returned if an invalid port specifier is provided.
+    \return The name of the port with the given Id is returned.
+    \retval An empty string is returned if an invalid port specifier
+            is provided. User code should assume a UTF-8 encoding.
   */
   std::string getPortName( unsigned int portNumber = 0 );
 
@@ -406,7 +459,17 @@ class RtMidiOut : public RtMidi
       An exception is thrown if an error occurs during output or an
       output connection was not previously established.
   */
-  void sendMessage( std::vector<unsigned char> *message );
+  void sendMessage( const std::vector<unsigned char> *message );
+
+  //! Immediately send a single message out an open MIDI output port.
+  /*!
+      An exception is thrown if an error occurs during output or an
+      output connection was not previously established.
+
+      \param message A pointer to the MIDI message as raw bytes
+      \param size    Length of the MIDI message in bytes
+  */
+  void sendMessage( const unsigned char *message, size_t size );
 
   //! Set an error callback function to be invoked when an error has occured.
   /*!
@@ -416,7 +479,7 @@ class RtMidiOut : public RtMidi
   virtual void setErrorCallback( RtMidiErrorCallback errorCallback = NULL, void *userData = 0 );
 
  protected:
-  void openMidiApi( RtMidi::Api api, const std::string clientName );
+  void openMidiApi( RtMidi::Api api, const std::string &clientName );
 };
 
 
@@ -433,16 +496,18 @@ class RtMidiOut : public RtMidi
 //
 // **************************************************************** //
 
-class MidiApi
+class RTMIDI_DLL_PUBLIC MidiApi
 {
  public:
 
   MidiApi();
   virtual ~MidiApi();
   virtual RtMidi::Api getCurrentApi( void ) = 0;
-  virtual void openPort( unsigned int portNumber, const std::string portName ) = 0;
-  virtual void openVirtualPort( const std::string portName ) = 0;
+  virtual void openPort( unsigned int portNumber, const std::string &portName ) = 0;
+  virtual void openVirtualPort( const std::string &portName ) = 0;
   virtual void closePort( void ) = 0;
+  virtual void setClientName( const std::string &clientName ) = 0;
+  virtual void setPortName( const std::string &portName ) = 0;
 
   virtual unsigned int getPortCount( void ) = 0;
   virtual std::string getPortName( unsigned int portNumber ) = 0;
@@ -464,7 +529,7 @@ protected:
   void *errorCallbackUserData_;
 };
 
-class MidiInApi : public MidiApi
+class RTMIDI_DLL_PUBLIC MidiInApi : public MidiApi
 {
  public:
 
@@ -477,25 +542,29 @@ class MidiInApi : public MidiApi
 
   // A MIDI structure used internally by the class to store incoming
   // messages.  Each message represents one and only one MIDI message.
-  struct MidiMessage { 
-    std::vector<unsigned char> bytes; 
+  struct MidiMessage {
+    std::vector<unsigned char> bytes;
+
+    //! Time in seconds elapsed since the previous message
     double timeStamp;
 
     // Default constructor.
-  MidiMessage()
-  :bytes(0), timeStamp(0.0) {}
+    MidiMessage()
+      : bytes(0), timeStamp(0.0) {}
   };
 
   struct MidiQueue {
     unsigned int front;
     unsigned int back;
-    unsigned int size;
     unsigned int ringSize;
     MidiMessage *ring;
 
     // Default constructor.
-  MidiQueue()
-  :front(0), back(0), size(0), ringSize(0) {}
+    MidiQueue()
+      : front(0), back(0), ringSize(0), ring(0) {}
+    bool push( const MidiMessage& );
+    bool pop( std::vector<unsigned char>*, double* );
+    unsigned int size( unsigned int *back=0, unsigned int *front=0 );
   };
 
   // The RtMidiInData structure is used to pass private class data to
@@ -513,23 +582,22 @@ class MidiInApi : public MidiApi
     bool continueSysex;
 
     // Default constructor.
-  RtMidiInData()
-  : ignoreFlags(7), doInput(false), firstMessage(true),
-      apiData(0), usingCallback(false), userCallback(0), userData(0),
-      continueSysex(false) {}
+    RtMidiInData()
+      : ignoreFlags(7), doInput(false), firstMessage(true), apiData(0), usingCallback(false),
+        userCallback(0), userData(0), continueSysex(false) {}
   };
 
  protected:
   RtMidiInData inputData_;
 };
 
-class MidiOutApi : public MidiApi
+class RTMIDI_DLL_PUBLIC MidiOutApi : public MidiApi
 {
  public:
 
   MidiOutApi( void );
   virtual ~MidiOutApi( void );
-  virtual void sendMessage( std::vector<unsigned char> *message ) = 0;
+  virtual void sendMessage( const unsigned char *message, size_t size ) = 0;
 };
 
 // **************************************************************** //
@@ -539,225 +607,27 @@ class MidiOutApi : public MidiApi
 // **************************************************************** //
 
 inline RtMidi::Api RtMidiIn :: getCurrentApi( void ) throw() { return rtapi_->getCurrentApi(); }
-inline void RtMidiIn :: openPort( unsigned int portNumber, const std::string portName ) { rtapi_->openPort( portNumber, portName ); }
-inline void RtMidiIn :: openVirtualPort( const std::string portName ) { rtapi_->openVirtualPort( portName ); }
+inline void RtMidiIn :: openPort( unsigned int portNumber, const std::string &portName ) { rtapi_->openPort( portNumber, portName ); }
+inline void RtMidiIn :: openVirtualPort( const std::string &portName ) { rtapi_->openVirtualPort( portName ); }
 inline void RtMidiIn :: closePort( void ) { rtapi_->closePort(); }
 inline bool RtMidiIn :: isPortOpen() const { return rtapi_->isPortOpen(); }
-inline void RtMidiIn :: setCallback( RtMidiCallback callback, void *userData ) { ((MidiInApi *)rtapi_)->setCallback( callback, userData ); }
-inline void RtMidiIn :: cancelCallback( void ) { ((MidiInApi *)rtapi_)->cancelCallback(); }
+inline void RtMidiIn :: setCallback( RtMidiCallback callback, void *userData ) { static_cast<MidiInApi *>(rtapi_)->setCallback( callback, userData ); }
+inline void RtMidiIn :: cancelCallback( void ) { static_cast<MidiInApi *>(rtapi_)->cancelCallback(); }
 inline unsigned int RtMidiIn :: getPortCount( void ) { return rtapi_->getPortCount(); }
 inline std::string RtMidiIn :: getPortName( unsigned int portNumber ) { return rtapi_->getPortName( portNumber ); }
-inline void RtMidiIn :: ignoreTypes( bool midiSysex, bool midiTime, bool midiSense ) { ((MidiInApi *)rtapi_)->ignoreTypes( midiSysex, midiTime, midiSense ); }
-inline double RtMidiIn :: getMessage( std::vector<unsigned char> *message ) { return ((MidiInApi *)rtapi_)->getMessage( message ); }
+inline void RtMidiIn :: ignoreTypes( bool midiSysex, bool midiTime, bool midiSense ) { static_cast<MidiInApi *>(rtapi_)->ignoreTypes( midiSysex, midiTime, midiSense ); }
+inline double RtMidiIn :: getMessage( std::vector<unsigned char> *message ) { return static_cast<MidiInApi *>(rtapi_)->getMessage( message ); }
 inline void RtMidiIn :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback(errorCallback, userData); }
 
 inline RtMidi::Api RtMidiOut :: getCurrentApi( void ) throw() { return rtapi_->getCurrentApi(); }
-inline void RtMidiOut :: openPort( unsigned int portNumber, const std::string portName ) { rtapi_->openPort( portNumber, portName ); }
-inline void RtMidiOut :: openVirtualPort( const std::string portName ) { rtapi_->openVirtualPort( portName ); }
+inline void RtMidiOut :: openPort( unsigned int portNumber, const std::string &portName ) { rtapi_->openPort( portNumber, portName ); }
+inline void RtMidiOut :: openVirtualPort( const std::string &portName ) { rtapi_->openVirtualPort( portName ); }
 inline void RtMidiOut :: closePort( void ) { rtapi_->closePort(); }
 inline bool RtMidiOut :: isPortOpen() const { return rtapi_->isPortOpen(); }
 inline unsigned int RtMidiOut :: getPortCount( void ) { return rtapi_->getPortCount(); }
 inline std::string RtMidiOut :: getPortName( unsigned int portNumber ) { return rtapi_->getPortName( portNumber ); }
-inline void RtMidiOut :: sendMessage( std::vector<unsigned char> *message ) { ((MidiOutApi *)rtapi_)->sendMessage( message ); }
+inline void RtMidiOut :: sendMessage( const std::vector<unsigned char> *message ) { static_cast<MidiOutApi *>(rtapi_)->sendMessage( &message->at(0), message->size() ); }
+inline void RtMidiOut :: sendMessage( const unsigned char *message, size_t size ) { static_cast<MidiOutApi *>(rtapi_)->sendMessage( message, size ); }
 inline void RtMidiOut :: setErrorCallback( RtMidiErrorCallback errorCallback, void *userData ) { rtapi_->setErrorCallback(errorCallback, userData); }
-
-// **************************************************************** //
-//
-// MidiInApi and MidiOutApi subclass prototypes.
-//
-// **************************************************************** //
-
-#if !defined(__LINUX_ALSA__) && !defined(__UNIX_JACK__) && !defined(__MACOSX_CORE__) && !defined(__WINDOWS_MM__)
-  #define __RTMIDI_DUMMY__
-#endif
-
-#if defined(__MACOSX_CORE__)
-
-class MidiInCore: public MidiInApi
-{
- public:
-  MidiInCore( const std::string clientName, unsigned int queueSizeLimit );
-  ~MidiInCore( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::MACOSX_CORE; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-
- protected:
-  void initialize( const std::string& clientName );
-};
-
-class MidiOutCore: public MidiOutApi
-{
- public:
-  MidiOutCore( const std::string clientName );
-  ~MidiOutCore( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::MACOSX_CORE; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-  void sendMessage( std::vector<unsigned char> *message );
-
- protected:
-  void initialize( const std::string& clientName );
-};
-
-#endif
-
-#if defined(__UNIX_JACK__)
-
-class MidiInJack: public MidiInApi
-{
- public:
-  MidiInJack( const std::string clientName, unsigned int queueSizeLimit );
-  ~MidiInJack( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::UNIX_JACK; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-
- protected:
-  std::string clientName;
-
-  void connect( void );
-  void initialize( const std::string& clientName );
-};
-
-class MidiOutJack: public MidiOutApi
-{
- public:
-  MidiOutJack( const std::string clientName );
-  ~MidiOutJack( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::UNIX_JACK; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-  void sendMessage( std::vector<unsigned char> *message );
-
- protected:
-  std::string clientName;
-
-  void connect( void );
-  void initialize( const std::string& clientName );
-};
-
-#endif
-
-#if defined(__LINUX_ALSA__)
-
-class MidiInAlsa: public MidiInApi
-{
- public:
-  MidiInAlsa( const std::string clientName, unsigned int queueSizeLimit );
-  ~MidiInAlsa( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::LINUX_ALSA; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-
- protected:
-  void initialize( const std::string& clientName );
-};
-
-class MidiOutAlsa: public MidiOutApi
-{
- public:
-  MidiOutAlsa( const std::string clientName );
-  ~MidiOutAlsa( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::LINUX_ALSA; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-  void sendMessage( std::vector<unsigned char> *message );
-
- protected:
-  void initialize( const std::string& clientName );
-};
-
-#endif
-
-#if defined(__WINDOWS_MM__)
-
-class MidiInWinMM: public MidiInApi
-{
- public:
-  MidiInWinMM( const std::string clientName, unsigned int queueSizeLimit );
-  ~MidiInWinMM( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::WINDOWS_MM; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-
- protected:
-  void initialize( const std::string& clientName );
-};
-
-class MidiOutWinMM: public MidiOutApi
-{
- public:
-  MidiOutWinMM( const std::string clientName );
-  ~MidiOutWinMM( void );
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::WINDOWS_MM; };
-  void openPort( unsigned int portNumber, const std::string portName );
-  void openVirtualPort( const std::string portName );
-  void closePort( void );
-  unsigned int getPortCount( void );
-  std::string getPortName( unsigned int portNumber );
-  void sendMessage( std::vector<unsigned char> *message );
-
- protected:
-  void initialize( const std::string& clientName );
-};
-
-#endif
-
-#if defined(__RTMIDI_DUMMY__)
-
-class MidiInDummy: public MidiInApi
-{
- public:
- MidiInDummy( const std::string /*clientName*/, unsigned int queueSizeLimit ) : MidiInApi( queueSizeLimit ) { errorString_ = "MidiInDummy: This class provides no functionality."; error( RtMidiError::WARNING, errorString_ ); }
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::RTMIDI_DUMMY; }
-  void openPort( unsigned int /*portNumber*/, const std::string /*portName*/ ) {}
-  void openVirtualPort( const std::string /*portName*/ ) {}
-  void closePort( void ) {}
-  unsigned int getPortCount( void ) { return 0; }
-  std::string getPortName( unsigned int portNumber ) { return ""; }
-
- protected:
-  void initialize( const std::string& /*clientName*/ ) {}
-};
-
-class MidiOutDummy: public MidiOutApi
-{
- public:
-  MidiOutDummy( const std::string /*clientName*/ ) { errorString_ = "MidiOutDummy: This class provides no functionality."; error( RtMidiError::WARNING, errorString_ ); }
-  RtMidi::Api getCurrentApi( void ) { return RtMidi::RTMIDI_DUMMY; }
-  void openPort( unsigned int /*portNumber*/, const std::string /*portName*/ ) {}
-  void openVirtualPort( const std::string /*portName*/ ) {}
-  void closePort( void ) {}
-  unsigned int getPortCount( void ) { return 0; }
-  std::string getPortName( unsigned int /*portNumber*/ ) { return ""; }
-  void sendMessage( std::vector<unsigned char> * /*message*/ ) {}
-
- protected:
-  void initialize( const std::string& /*clientName*/ ) {}
-};
-
-#endif
 
 #endif

--- a/rtmidi/rtmidi_c.cpp
+++ b/rtmidi/rtmidi_c.cpp
@@ -3,45 +3,86 @@
 #include "rtmidi_c.h"
 #include "RtMidi.h"
 
-/* misc */
-int rtmidi_sizeof_rtmidi_api ()
+/* Compile-time assertions that will break if the enums are changed in
+ * the future without synchronizing them properly.  If you get (g++)
+ * "error: ‘StaticAssert<b>::StaticAssert() [with bool b = false]’ is
+ * private within this context", it means enums are not aligned. */
+template<bool b> class StaticAssert { private: StaticAssert() {} };
+template<> class StaticAssert<true>{ public: StaticAssert() {} };
+#define ENUM_EQUAL(x,y) StaticAssert<(int)x==(int)y>()
+class StaticAssertions { StaticAssertions() {
+    ENUM_EQUAL( RTMIDI_API_UNSPECIFIED,     RtMidi::UNSPECIFIED );
+    ENUM_EQUAL( RTMIDI_API_MACOSX_CORE,     RtMidi::MACOSX_CORE );
+    ENUM_EQUAL( RTMIDI_API_LINUX_ALSA,      RtMidi::LINUX_ALSA );
+    ENUM_EQUAL( RTMIDI_API_UNIX_JACK,       RtMidi::UNIX_JACK );
+    ENUM_EQUAL( RTMIDI_API_WINDOWS_MM,      RtMidi::WINDOWS_MM );
+    ENUM_EQUAL( RTMIDI_API_RTMIDI_DUMMY,    RtMidi::RTMIDI_DUMMY );
+
+    ENUM_EQUAL( RTMIDI_ERROR_WARNING,            RtMidiError::WARNING );
+    ENUM_EQUAL( RTMIDI_ERROR_DEBUG_WARNING,      RtMidiError::DEBUG_WARNING );
+    ENUM_EQUAL( RTMIDI_ERROR_UNSPECIFIED,        RtMidiError::UNSPECIFIED );
+    ENUM_EQUAL( RTMIDI_ERROR_NO_DEVICES_FOUND,   RtMidiError::NO_DEVICES_FOUND );
+    ENUM_EQUAL( RTMIDI_ERROR_INVALID_DEVICE,     RtMidiError::INVALID_DEVICE );
+    ENUM_EQUAL( RTMIDI_ERROR_MEMORY_ERROR,       RtMidiError::MEMORY_ERROR );
+    ENUM_EQUAL( RTMIDI_ERROR_INVALID_PARAMETER,  RtMidiError::INVALID_PARAMETER );
+    ENUM_EQUAL( RTMIDI_ERROR_INVALID_USE,        RtMidiError::INVALID_USE );
+    ENUM_EQUAL( RTMIDI_ERROR_DRIVER_ERROR,       RtMidiError::DRIVER_ERROR );
+    ENUM_EQUAL( RTMIDI_ERROR_SYSTEM_ERROR,       RtMidiError::SYSTEM_ERROR );
+    ENUM_EQUAL( RTMIDI_ERROR_THREAD_ERROR,       RtMidiError::THREAD_ERROR );
+}};
+
+class CallbackProxyUserData
 {
-	return sizeof (RtMidiApi);
-}
+  public:
+	CallbackProxyUserData (RtMidiCCallback cCallback, void *userData)
+		: c_callback (cCallback), user_data (userData)
+	{
+	}
+	RtMidiCCallback c_callback;
+	void *user_data;
+};
+
+extern "C" const enum RtMidiApi rtmidi_compiled_apis[]; // casting from RtMidi::Api[]
+extern "C" const unsigned int rtmidi_num_compiled_apis;
 
 /* RtMidi API */
-int rtmidi_get_compiled_api (enum RtMidiApi **apis) // return length for NULL argument.
+int rtmidi_get_compiled_api (enum RtMidiApi *apis, unsigned int apis_size)
 {
-	if (!apis || !(*apis)) {
-		std::vector<RtMidi::Api> *v = new std::vector<RtMidi::Api> ();
-		try {
-			RtMidi::getCompiledApi (*v);
-			int size = v->size ();
-			delete v;
-			return size;
-		} catch (...) {
-			return -1;
-		}
-	} else {
-		try {
-			std::vector<RtMidi::Api> *v = new std::vector<RtMidi::Api> ();
-			RtMidi::getCompiledApi (*v);
-			for (unsigned int i = 0; i < v->size (); i++)
-				(*apis) [i] = (RtMidiApi) v->at (i);
-			delete v;
-			return 0;
-		} catch (...) {
-			return -1;
-		}
-	}
+    unsigned num = rtmidi_num_compiled_apis;
+    if (apis) {
+        num = (num < apis_size) ? num : apis_size;
+        memcpy(apis, rtmidi_compiled_apis, num * sizeof(enum RtMidiApi));
+    }
+    return (int)num;
 }
 
-void rtmidi_error (RtMidiPtr device, enum RtMidiErrorType type, const char* errorString)
+extern "C" const char* rtmidi_api_names[][2];
+const char *rtmidi_api_name(enum RtMidiApi api) {
+    if (api < 0 || api >= RTMIDI_API_NUM)
+        return NULL;
+    return rtmidi_api_names[api][0];
+}
+
+const char *rtmidi_api_display_name(enum RtMidiApi api)
+{
+    if (api < 0 || api >= RTMIDI_API_NUM)
+        return "Unknown";
+    return rtmidi_api_names[api][1];
+}
+
+enum RtMidiApi rtmidi_compiled_api_by_name(const char *name) {
+    RtMidi::Api api = RtMidi::UNSPECIFIED;
+    if (name) {
+        api = RtMidi::getCompiledApiByName(name);
+    }
+    return (enum RtMidiApi)api;
+}
+
+void rtmidi_error (MidiApi *api, enum RtMidiErrorType type, const char* errorString)
 {
 	std::string msg = errorString;
-	((MidiApi*) device->ptr)->error ((RtMidiError::Type) type, msg);
+	api->error ((RtMidiError::Type) type, msg);
 }
-
 
 void rtmidi_open_port (RtMidiPtr device, unsigned int portNumber, const char *portName)
 {
@@ -113,11 +154,13 @@ RtMidiInPtr rtmidi_in_create_default ()
         RtMidiIn* rIn = new RtMidiIn ();
         
         wrp->ptr = (void*) rIn;
+        wrp->data = 0;
         wrp->ok  = true;
         wrp->msg = "";
     
     } catch (const RtMidiError & err) {
         wrp->ptr = 0;
+        wrp->data = 0;
         wrp->ok  = false;
         wrp->msg = err.what ();
     }
@@ -134,11 +177,13 @@ RtMidiInPtr rtmidi_in_create (enum RtMidiApi api, const char *clientName, unsign
         RtMidiIn* rIn = new RtMidiIn ((RtMidi::Api) api, name, queueSizeLimit);
         
         wrp->ptr = (void*) rIn;
+        wrp->data = 0;
         wrp->ok  = true;
         wrp->msg = "";
 
     } catch (const RtMidiError & err) {
-        wrp->ptr = 0; 
+        wrp->ptr = 0;
+        wrp->data = 0;
         wrp->ok  = false;
         wrp->msg = err.what ();
     }
@@ -148,6 +193,8 @@ RtMidiInPtr rtmidi_in_create (enum RtMidiApi api, const char *clientName, unsign
 
 void rtmidi_in_free (RtMidiInPtr device)
 {
+    if (device->data)
+      delete (CallbackProxyUserData*) device->data;
     delete (RtMidiIn*) device->ptr;
     delete device;
 }
@@ -161,21 +208,11 @@ enum RtMidiApi rtmidi_in_get_current_api (RtMidiPtr device)
         device->ok  = false;
         device->msg = err.what ();
 
-        return RT_MIDI_API_UNSPECIFIED;
+        return RTMIDI_API_UNSPECIFIED;
     }
 }
 
-class CallbackProxyUserData
-{
-  public:
-	CallbackProxyUserData (RtMidiCCallback cCallback, void *userData)
-		: c_callback (cCallback), user_data (userData)
-	{
-	}
-	RtMidiCCallback c_callback;
-	void *user_data;
-};
-
+static
 void callback_proxy (double timeStamp, std::vector<unsigned char> *message, void *userData)
 {
 	CallbackProxyUserData* data = reinterpret_cast<CallbackProxyUserData*> (userData);
@@ -184,13 +221,14 @@ void callback_proxy (double timeStamp, std::vector<unsigned char> *message, void
 
 void rtmidi_in_set_callback (RtMidiInPtr device, RtMidiCCallback callback, void *userData)
 {
+    device->data = (void*) new CallbackProxyUserData (callback, userData);
     try {
-        void *data = (void *) new CallbackProxyUserData (callback, userData);
-        ((RtMidiIn*) device->ptr)->setCallback (callback_proxy, data);
-    
+        ((RtMidiIn*) device->ptr)->setCallback (callback_proxy, device->data);
     } catch (const RtMidiError & err) {
         device->ok  = false;
         device->msg = err.what ();
+        delete (CallbackProxyUserData*) device->data;
+        device->data = 0;
     }
 }
 
@@ -198,7 +236,8 @@ void rtmidi_in_cancel_callback (RtMidiInPtr device)
 {
     try {
         ((RtMidiIn*) device->ptr)->cancelCallback ();
-
+        delete (CallbackProxyUserData*) device->data;
+        device->data = 0;
     } catch (const RtMidiError & err) {
         device->ok  = false;
         device->msg = err.what ();
@@ -211,21 +250,19 @@ void rtmidi_in_ignore_types (RtMidiInPtr device, bool midiSysex, bool midiTime, 
 }
 
 double rtmidi_in_get_message (RtMidiInPtr device, 
-                              unsigned char **message, 
-                              size_t * size)
+                              unsigned char *message,
+                              size_t *size)
 {
     try {
         // FIXME: use allocator to achieve efficient buffering
-        std::vector<unsigned char> *v = new std::vector<unsigned char> ();
-        double ret = ((RtMidiIn*) device->ptr)->getMessage (v);
-        *size = v->size ();
+        std::vector<unsigned char> v;
+        double ret = ((RtMidiIn*) device->ptr)->getMessage (&v);
 
-        if (v->size () > 0) {
-            *message = (unsigned char *) 
-                        malloc (sizeof (unsigned char *) * (int) v->size ());
-            memcpy (*message, v->data (), (int) v->size ());
+        if (v.size () > 0 && v.size() <= *size) {
+            memcpy (message, v.data (), (int) v.size ());
         }
-        delete v;
+
+        *size = v.size();
         return ret;
     } 
     catch (const RtMidiError & err) {
@@ -249,11 +286,13 @@ RtMidiOutPtr rtmidi_out_create_default ()
         RtMidiOut* rOut = new RtMidiOut ();
         
         wrp->ptr = (void*) rOut;
+        wrp->data = 0;
         wrp->ok  = true;
         wrp->msg = "";
     
     } catch (const RtMidiError & err) {
         wrp->ptr = 0;
+        wrp->data = 0;
         wrp->ok  = false;
         wrp->msg = err.what ();
     }
@@ -270,11 +309,13 @@ RtMidiOutPtr rtmidi_out_create (enum RtMidiApi api, const char *clientName)
         RtMidiOut* rOut = new RtMidiOut ((RtMidi::Api) api, name);
         
         wrp->ptr = (void*) rOut;
+        wrp->data = 0;
         wrp->ok  = true;
         wrp->msg = "";
     
     } catch (const RtMidiError & err) {
         wrp->ptr = 0;
+        wrp->data = 0;
         wrp->ok  = false;
         wrp->msg = err.what ();
     }
@@ -298,18 +339,14 @@ enum RtMidiApi rtmidi_out_get_current_api (RtMidiPtr device)
         device->ok  = false;
         device->msg = err.what ();
 
-        return RT_MIDI_API_UNSPECIFIED;
+        return RTMIDI_API_UNSPECIFIED;
     }
 }
 
 int rtmidi_out_send_message (RtMidiOutPtr device, const unsigned char *message, int length)
 {
     try {
-        // FIXME: use allocator to achieve efficient buffering
-        std::vector<unsigned char> *v = new std::vector<unsigned char> (length);
-        memcpy (v->data (), message, length);
-        ((RtMidiOut*) device->ptr)->sendMessage (v);
-        delete v;
+        ((RtMidiOut*) device->ptr)->sendMessage (message, length);
         return 0;
     }
     catch (const RtMidiError & err) {

--- a/rtmidi/rtmidi_c.h
+++ b/rtmidi/rtmidi_c.h
@@ -1,12 +1,32 @@
+/************************************************************************/
+/*! \defgroup C-interface
+    @{
+
+    \brief C interface to realtime MIDI input/output C++ classes.
+
+    RtMidi offers a C-style interface, principally for use in binding
+    RtMidi to other programming languages.  All structs, enums, and
+    functions listed here have direct analogs (and simply call to)
+    items in the C++ RtMidi class and its supporting classes and
+    types
+*/
+/************************************************************************/
+
+/*!
+  \file rtmidi_c.h
+ */
 
 #include <stdbool.h>
+#include <stddef.h>
 #ifndef RTMIDI_C_H
 #define RTMIDI_C_H
 
-#include <stdlib.h>
-
 #if defined(RTMIDI_EXPORT)
+#if defined _WIN32 || defined __CYGWIN__
 #define RTMIDIAPI __declspec(dllexport)
+#else
+#define RTMIDIAPI __attribute__((visibility("default")))
+#endif
 #else
 #define RTMIDIAPI //__declspec(dllimport)
 #endif
@@ -15,61 +35,206 @@
 extern "C" {
 #endif
 
+//! \brief Wraps an RtMidi object for C function return statuses.
 struct RtMidiWrapper {
+    //! The wrapped RtMidi object.
     void* ptr;
+    void* data;
+
+    //! True when the last function call was OK. 
     bool  ok;
+
+    //! If an error occured (ok != true), set to an error message.
     const char* msg;
 };
 
-typedef RtMidiWrapper* RtMidiPtr;
-typedef RtMidiWrapper* RtMidiInPtr;
-typedef RtMidiWrapper* RtMidiOutPtr;
+//! \brief Typedef for a generic RtMidi pointer.
+typedef struct RtMidiWrapper* RtMidiPtr;
 
-  enum RtMidiApi {
-    RT_MIDI_API_UNSPECIFIED,    /*!< Search for a working compiled API. */
-    RT_MIDI_API_MACOSX_CORE,    /*!< Macintosh OS-X Core Midi API. */
-    RT_MIDI_API_LINUX_ALSA,     /*!< The Advanced Linux Sound Architecture API. */
-    RT_MIDI_API_UNIX_JACK,      /*!< The Jack Low-Latency MIDI Server API. */
-    RT_MIDI_API_WINDOWS_MM,     /*!< The Microsoft Multimedia MIDI API. */
-    RT_MIDI_API_WINDOWS_KS,     /*!< The Microsoft Kernel Streaming MIDI API. */
-    RT_MIDI_API_RTMIDI_DUMMY    /*!< A compilable but non-functional API. */
-  };
+//! \brief Typedef for a generic RtMidiIn pointer.
+typedef struct RtMidiWrapper* RtMidiInPtr;
 
-enum RtMidiErrorType {
-  RT_ERROR_WARNING, RT_ERROR_DEBUG_WARNING, RT_ERROR_UNSPECIFIED, RT_ERROR_NO_DEVICES_FOUND,
-  RT_ERROR_INVALID_DEVICE, RT_ERROR_MEMORY_ERROR, RT_ERROR_INVALID_PARAMETER, RT_ERROR_INVALID_USE,
-  RT_ERROR_DRIVER_ERROR, RT_ERROR_SYSTEM_ERROR, RT_ERROR_THREAD_ERROR
+//! \brief Typedef for a generic RtMidiOut pointer.
+typedef struct RtMidiWrapper* RtMidiOutPtr;
+
+//! \brief MIDI API specifier arguments.  See \ref RtMidi::Api.
+enum RtMidiApi {
+    RTMIDI_API_UNSPECIFIED,    /*!< Search for a working compiled API. */
+    RTMIDI_API_MACOSX_CORE,    /*!< Macintosh OS-X CoreMIDI API. */
+    RTMIDI_API_LINUX_ALSA,     /*!< The Advanced Linux Sound Architecture API. */
+    RTMIDI_API_UNIX_JACK,      /*!< The Jack Low-Latency MIDI Server API. */
+    RTMIDI_API_WINDOWS_MM,     /*!< The Microsoft Multimedia MIDI API. */
+    RTMIDI_API_RTMIDI_DUMMY,   /*!< A compilable but non-functional API. */
+    RTMIDI_API_NUM             /*!< Number of values in this enum. */
 };
 
-typedef void(* RtMidiCCallback) (double timeStamp, const unsigned char* message, unsigned int msg_len, void *userData);
+//! \brief Defined RtMidiError types. See \ref RtMidiError::Type.
+enum RtMidiErrorType {
+  RTMIDI_ERROR_WARNING,           /*!< A non-critical error. */
+  RTMIDI_ERROR_DEBUG_WARNING,     /*!< A non-critical error which might be useful for debugging. */
+  RTMIDI_ERROR_UNSPECIFIED,       /*!< The default, unspecified error type. */
+  RTMIDI_ERROR_NO_DEVICES_FOUND,  /*!< No devices found on system. */
+  RTMIDI_ERROR_INVALID_DEVICE,    /*!< An invalid device ID was specified. */
+  RTMIDI_ERROR_MEMORY_ERROR,      /*!< An error occured during memory allocation. */
+  RTMIDI_ERROR_INVALID_PARAMETER, /*!< An invalid parameter was specified to a function. */
+  RTMIDI_ERROR_INVALID_USE,       /*!< The function was called incorrectly. */
+  RTMIDI_ERROR_DRIVER_ERROR,      /*!< A system driver error occured. */
+  RTMIDI_ERROR_SYSTEM_ERROR,      /*!< A system error occured. */
+  RTMIDI_ERROR_THREAD_ERROR       /*!< A thread error occured. */
+};
 
-RTMIDIAPI int rtmidi_sizeof_rtmidi_api ();
+/*! \brief The type of a RtMidi callback function.
+ *
+ * \param timeStamp   The time at which the message has been received.
+ * \param message     The midi message.
+ * \param userData    Additional user data for the callback.
+ *
+ * See \ref RtMidiIn::RtMidiCallback.
+ */
+typedef void(* RtMidiCCallback) (double timeStamp, const unsigned char* message,
+                                 size_t messageSize, void *userData);
+
 
 /* RtMidi API */
-RTMIDIAPI int rtmidi_get_compiled_api (enum RtMidiApi **apis); // return length for NULL argument.
-RTMIDIAPI void rtmidi_error (RtMidiPtr device, enum RtMidiErrorType type, const char* errorString);
 
+/*! \brief Determine the available compiled MIDI APIs.
+ *
+ * If the given `apis` parameter is null, returns the number of available APIs.
+ * Otherwise, fill the given apis array with the RtMidi::Api values.
+ *
+ * \param apis  An array or a null value.
+ * \param apis_size  Number of elements pointed to by apis
+ * \return number of items needed for apis array if apis==NULL, or
+ *         number of items written to apis array otherwise.  A negative
+ *         return value indicates an error.
+ *
+ * See \ref RtMidi::getCompiledApi().
+*/
+RTMIDIAPI int rtmidi_get_compiled_api (enum RtMidiApi *apis, unsigned int apis_size);
+
+//! \brief Return the name of a specified compiled MIDI API.
+//! See \ref RtMidi::getApiName().
+RTMIDIAPI const char *rtmidi_api_name(enum RtMidiApi api);
+
+//! \brief Return the display name of a specified compiled MIDI API.
+//! See \ref RtMidi::getApiDisplayName().
+RTMIDIAPI const char *rtmidi_api_display_name(enum RtMidiApi api);
+
+//! \brief Return the compiled MIDI API having the given name.
+//! See \ref RtMidi::getCompiledApiByName().
+RTMIDIAPI enum RtMidiApi rtmidi_compiled_api_by_name(const char *name);
+
+//! \internal Report an error.
+RTMIDIAPI void rtmidi_error (enum RtMidiErrorType type, const char* errorString);
+
+/*! \brief Open a MIDI port.
+ *
+ * \param port      Must be greater than 0
+ * \param portName  Name for the application port.
+ *
+ * See RtMidi::openPort().
+ */
 RTMIDIAPI void rtmidi_open_port (RtMidiPtr device, unsigned int portNumber, const char *portName);
+
+/*! \brief Creates a virtual MIDI port to which other software applications can 
+ * connect.  
+ *
+ * \param portName  Name for the application port.
+ *
+ * See RtMidi::openVirtualPort().
+ */
 RTMIDIAPI void rtmidi_open_virtual_port (RtMidiPtr device, const char *portName);
+
+/*! \brief Close a MIDI connection.
+ * See RtMidi::closePort().
+ */
 RTMIDIAPI void rtmidi_close_port (RtMidiPtr device);
+
+/*! \brief Return the number of available MIDI ports.
+ * See RtMidi::getPortCount().
+ */
 RTMIDIAPI unsigned int rtmidi_get_port_count (RtMidiPtr device);
+
+/*! \brief Return a string identifier for the specified MIDI input port number.
+ * See RtMidi::getPortName().
+ */
 RTMIDIAPI const char* rtmidi_get_port_name (RtMidiPtr device, unsigned int portNumber);
 
 /* RtMidiIn API */
-RTMIDIAPI RtMidiInPtr rtmidi_in_create_default ();
+
+//! \brief Create a default RtMidiInPtr value, with no initialization.
+RTMIDIAPI RtMidiInPtr rtmidi_in_create_default (void);
+
+/*! \brief Create a  RtMidiInPtr value, with given api, clientName and queueSizeLimit.
+ *
+ *  \param api            An optional API id can be specified.
+ *  \param clientName     An optional client name can be specified. This
+ *                        will be used to group the ports that are created
+ *                        by the application.
+ *  \param queueSizeLimit An optional size of the MIDI input queue can be
+ *                        specified.
+ *
+ * See RtMidiIn::RtMidiIn().
+ */
 RTMIDIAPI RtMidiInPtr rtmidi_in_create (enum RtMidiApi api, const char *clientName, unsigned int queueSizeLimit);
+
+//! \brief Free the given RtMidiInPtr.
 RTMIDIAPI void rtmidi_in_free (RtMidiInPtr device);
+
+//! \brief Returns the MIDI API specifier for the given instance of RtMidiIn.
+//! See \ref RtMidiIn::getCurrentApi().
 RTMIDIAPI enum RtMidiApi rtmidi_in_get_current_api (RtMidiPtr device);
+
+//! \brief Set a callback function to be invoked for incoming MIDI messages.
+//! See \ref RtMidiIn::setCallback().
 RTMIDIAPI void rtmidi_in_set_callback (RtMidiInPtr device, RtMidiCCallback callback, void *userData);
+
+//! \brief Cancel use of the current callback function (if one exists).
+//! See \ref RtMidiIn::cancelCallback().
 RTMIDIAPI void rtmidi_in_cancel_callback (RtMidiInPtr device);
+
+//! \brief Specify whether certain MIDI message types should be queued or ignored during input.
+//! See \ref RtMidiIn::ignoreTypes().
 RTMIDIAPI void rtmidi_in_ignore_types (RtMidiInPtr device, bool midiSysex, bool midiTime, bool midiSense);
-RTMIDIAPI double rtmidi_in_get_message (RtMidiInPtr device, unsigned char **message, size_t * size);
+
+/*! Fill the user-provided array with the data bytes for the next available
+ * MIDI message in the input queue and return the event delta-time in seconds.
+ *
+ * \param message   Must point to a char* that is already allocated.
+ *                  SYSEX messages maximum size being 1024, a statically
+ *                  allocated array could
+ *                  be sufficient. 
+ * \param size      Is used to return the size of the message obtained. 
+ *
+ * See RtMidiIn::getMessage().
+ */
+RTMIDIAPI double rtmidi_in_get_message (RtMidiInPtr device, unsigned char *message, size_t *size);
 
 /* RtMidiOut API */
-RTMIDIAPI RtMidiOutPtr rtmidi_out_create_default ();
+
+//! \brief Create a default RtMidiInPtr value, with no initialization.
+RTMIDIAPI RtMidiOutPtr rtmidi_out_create_default (void);
+
+/*! \brief Create a RtMidiOutPtr value, with given and clientName.
+ *
+ *  \param api            An optional API id can be specified.
+ *  \param clientName     An optional client name can be specified. This
+ *                        will be used to group the ports that are created
+ *                        by the application.
+ *
+ * See RtMidiOut::RtMidiOut().
+ */
 RTMIDIAPI RtMidiOutPtr rtmidi_out_create (enum RtMidiApi api, const char *clientName);
+
+//! \brief Free the given RtMidiOutPtr.
 RTMIDIAPI void rtmidi_out_free (RtMidiOutPtr device);
+
+//! \brief Returns the MIDI API specifier for the given instance of RtMidiOut.
+//! See \ref RtMidiOut::getCurrentApi().
 RTMIDIAPI enum RtMidiApi rtmidi_out_get_current_api (RtMidiPtr device);
+
+//! \brief Immediately send a single message out an open MIDI output port.
+//! See \ref RtMidiOut::sendMessage().
 RTMIDIAPI int rtmidi_out_send_message (RtMidiOutPtr device, const unsigned char *message, int length);
 
 
@@ -77,3 +242,5 @@ RTMIDIAPI int rtmidi_out_send_message (RtMidiOutPtr device, const unsigned char 
 }
 #endif
 #endif
+
+/*! }@ */


### PR DESCRIPTION
More maintenance work (https://github.com/riottracker/RtMidi/issues/3)

Depends on https://github.com/riottracker/RtMidi/pull/4

I upgraded RtMidi and had to update the Wrapper struct. I took the opportunity to use
hsc for the Storable calculations.

I also wrapped Device into InputDevice and OutputDevice. They can be used generically
with the `IsDevice` contstraint.

There were a lot of places that were just ignoring errors, so I vetted the c wrapper and
put in error guards in the right places.

I also removed C FFI types from the public API, opting for Double over CDouble and Word8 over CUChar.

I think there's a much simpler higher-level interface to be made, since the whole port/device thing
is still a bit confusing to me. (Also the `defaultInput/Output` pattern from the underlying library
 is a real code smell.) I haven't done anything there yet.