### PR TITLE
API changes: getMessageSize, getMessage, portName, listPorts

### DIFF
--- a/examples/poll.hs
+++ b/examples/poll.hs
@@ -5,7 +5,7 @@ import Control.Monad (forever)
 mainLoop :: InputDevice -> IO ()
 mainLoop d = do
   m <- getMessage d
-  if length (fst m) > 0 then
+  if length (snd m) > 0 then
     putStrLn $ show m
   else return ()
 

--- a/examples/query.hs
+++ b/examples/query.hs
@@ -1,14 +1,12 @@
-import Sound.RtMidi (closeDevice, compiledApis, createOutput, currentApi, defaultOutput, portCount, portName)
+import Sound.RtMidi (closeDevice, compiledApis, createOutput, currentApi, defaultOutput, listPorts)
 
 main :: IO ()
 main = do
   device <- defaultOutput
   api <- currentApi device
   builtin <- compiledApis
-  numPorts <- portCount device
-  portNames <- mapM (portName device) [0..numPorts-1]
+  portPairs <- listPorts device
   putStrLn $ "RtMidi output using " ++ (show api)
   putStrLn $ "built-in: " ++ (show builtin)
-  putStrLn $ "available Ports: " ++ (show numPorts)
-  putStrLn (show portNames)
+  putStrLn $ "available ports: " ++ (show portPairs)
   closeDevice device


### PR DESCRIPTION
This PR contains a few API changes to make it easier to use RtMidi:

1. RtMidi will silently drop large messages if you don't allocate enough room for them in `getMessage`! If you're not using sysex, then allocating 4kb buffers to receive each message might annoy you, so we make it configurable with `getMessageSized`.
2. Reorder the output tuple of `getMessage` to match that of the callback, so you can curry/uncurry one function definition to use either.
3. Modify the signature of `portName` to return `Maybe String`, saving the user from having to know that empty strings mean bad ports.
4. Providing a `listPorts` function for user convenience of enumerating ports and omitting bad ones.