### PR TITLE
Add MonadIO/MonadUnliftIO constraints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
     steps:
     - run:
         name: Install apt
-        command: "apt-get update && apt-get install -y $(cat docker/packages.txt)"
+        command: if [ -f docker/packages.txt ]; then apt-get update && apt-get install -y $(cat docker/packages.txt); fi
 
 jobs:
   stack_build:
@@ -23,8 +23,8 @@ jobs:
     docker:
       - image: haskell:<< parameters.lts_ghc_ver >>
     steps:
-      - install_native_deps
       - checkout
+      - install_native_deps
       - restore_cache:
           name: Restore cached dependencies
           keys:
@@ -45,8 +45,8 @@ jobs:
     docker:
       - image: haskell:<< parameters.ghc_ver >>
     steps:
-      - install_native_deps
       - checkout
+      - install_native_deps
       - restore_cache:
           name: Restore cached dependencies
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ commands:
   install_native_deps:
     steps:
     - run:
-      name: Install apt
-      command: "apt-get update && apt-get install -y $(cat docker/packages.txt)"
+        name: Install apt
+        command: "apt-get update && apt-get install -y $(cat docker/packages.txt)"
 
 jobs:
   stack_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
           keys:
             - stack-<< pipeline.parameters.cache_ver >>-{{ checksum "stack.yaml" }}-{{ checksum "<< pipeline.parameters.project >>.cabal" }}
       - run:
-          name: Run tests
-          command: stack test --flag RtMidi:jack
+          name: Build project
+          command: stack build --flag RtMidi:jack
       - save_cache:
           name: Cache dependencies
           key: stack-<< pipeline.parameters.cache_ver >>-{{ checksum "stack.yaml" }}-{{ checksum "<< pipeline.parameters.project >>.cabal" }}
@@ -57,9 +57,6 @@ jobs:
       - run:
           name: Build project
           command: cabal build -fjack
-      - run:
-          name: Run tests
-          command: cabal test
       - save_cache:
           name: Cache dependencies
           key: cabal-<< pipeline.parameters.cache_ver >>-<< parameters.ghc_ver >>-{{ checksum "<< pipeline.parameters.project >>.cabal" }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /dist
 /dist-newstyle
 /stack.yaml.lock
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ lint:
 	# Run hlint over our haskell source
 	stack exec -- hlint -i 'Parse error' -i 'Reduce duplication' Sound
 
+# Dockerized dev targets follow. Yes, this is built into stack, but
+# It's defined here to use for cabal too.
+
 .PHONY: docker-build
 docker-build:
 	# Build a development image for testing builds on linux

--- a/RtMidi.cabal
+++ b/RtMidi.cabal
@@ -102,6 +102,18 @@ executable rtmidi-query
   default-language:   Haskell2010
   ghc-options: -threaded -rtsopts
 
+test-suite rtmidi-test
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: test
+  build-depends:
+      base
+    , RtMidi
+    , tasty >= 1.2.3 && < 2
+    , tasty-hunit >= 0.10.0.2 && < 1
+  default-language:   Haskell2010
+  ghc-options: -threaded -rtsopts
+
 source-repository head
   type:     git
   location: https://github.com/riottracker/RtMidi

--- a/RtMidi.cabal
+++ b/RtMidi.cabal
@@ -44,6 +44,7 @@ library
   exposed-modules:     Sound.RtMidi
   other-modules:       Sound.RtMidi.Foreign
   build-depends:       base >=4.9 && <4.15
+                     , unliftio-core >= 0.1.2.0 && < 1
   default-language:    Haskell2010
   include-dirs:        rtmidi
   extra-libraries:     stdc++

--- a/Sound/RtMidi.hs
+++ b/Sound/RtMidi.hs
@@ -195,9 +195,11 @@ listPorts d = liftIO $ portCount d >>= go [] 0 where
 -- | Convenience function to lookup the first port satisfying the predicate.
 --
 -- You may want to find an exact name:
+--
 -- > findPort d (== name)
 --
 -- Or you may want to match part of a name:
+--
 -- > findPort d (isInfixOf name)
 --
 -- Note that if you are performing many lookups, it's better to use 'listPorts' and

--- a/Sound/RtMidi.hs
+++ b/Sound/RtMidi.hs
@@ -14,6 +14,7 @@ module Sound.RtMidi
   , portCount
   , portName
   , listPorts
+  , lookupPort
   , defaultInput
   , createInput
   , setCallback
@@ -188,6 +189,21 @@ listPorts d = portCount d >>= go [] 0 where
         mn <- portName d i
         let acc' = maybe acc (\n -> (i, n):acc) mn
         go acc' (succ i) c
+
+-- | Convenience function to lookup port by name.
+--
+-- Note that if you are performing many lookups, it's better to use 'listPorts' and
+-- do the lookups yourself (see the caveats there too).
+lookupPort :: IsDevice d => d -> String -> IO (Maybe Int)
+lookupPort d x = portCount d >>= go 0 where
+  go i c =
+    if i >= c
+      then pure Nothing
+      else do
+        mn <- portName d i
+        case mn of
+          Just n | x == n -> pure (Just i)
+          _ -> go (succ i) c
 
 -- | Default constructor for a 'Device' to use for input.
 defaultInput :: IO InputDevice

--- a/Sound/RtMidi.hs
+++ b/Sound/RtMidi.hs
@@ -29,10 +29,10 @@ module Sound.RtMidi
   , currentApi
   ) where
 
-import Control.Monad.IO.Class (MonadIO (..))
-import Control.Monad.IO.Unlift (MonadUnliftIO (..))
 import Control.Exception (Exception, throwIO)
 import Control.Monad (unless)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.IO.Unlift (MonadUnliftIO (..))
 import Data.Coerce (coerce)
 import Data.Word (Word8)
 import Foreign (FunPtr, Ptr, Storable (..), alloca, allocaArray, nullPtr, peekArray, with, withArrayLen)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,7 +3,7 @@ module Main (main) where
 import Control.Concurrent (threadDelay)
 import Control.Monad (replicateM_)
 import Data.IORef (IORef, newIORef, readIORef, modifyIORef)
-import Data.List (find, isInfixOf)
+import Data.List (isInfixOf)
 import Data.Word (Word8)
 import Sound.RtMidi (closeDevice, closePort, defaultInput, defaultOutput, findPort, sendMessage, setCallback, openPort, openVirtualPort)
 import Test.Tasty (TestTree, defaultMain, testGroup)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -3,8 +3,9 @@ module Main (main) where
 import Control.Concurrent (threadDelay)
 import Control.Monad (replicateM_)
 import Data.IORef (IORef, newIORef, readIORef, modifyIORef)
+import Data.List (find, isInfixOf)
 import Data.Word (Word8)
-import Sound.RtMidi (closeDevice, closePort, defaultInput, defaultOutput, lookupPort, sendMessage, setCallback, openPort, openVirtualPort)
+import Sound.RtMidi (closeDevice, closePort, defaultInput, defaultOutput, findPort, sendMessage, setCallback, openPort, openVirtualPort)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 
@@ -29,7 +30,7 @@ testVirtualReadWrite = testCase "virtual read write" $ do
   openVirtualPort inDev portName
   -- Create writer and connect to reader virtual port
   outDev <- defaultOutput
-  maybePortNum <- lookupPort outDev portName
+  maybePortNum <- findPort outDev (isInfixOf portName)
   let portNum = maybe (error "Could not find port") id maybePortNum
   openPort outDev portNum portName
   -- Send messages

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,0 +1,50 @@
+module Main (main) where
+
+import Control.Concurrent (threadDelay)
+import Control.Monad (replicateM_)
+import Data.IORef (IORef, newIORef, readIORef, modifyIORef)
+import Data.Word (Word8)
+import Sound.RtMidi (closeDevice, closePort, defaultInput, defaultOutput, lookupPort, sendMessage, setCallback, openPort, openVirtualPort)
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+
+incIORef :: IORef Int -> IO ()
+incIORef = flip modifyIORef succ
+
+readerCallback :: IORef Int -> Double -> [Word8] -> IO ()
+readerCallback countRef _ msg = incIORef countRef
+
+testVirtualReadWrite :: TestTree
+testVirtualReadWrite = testCase "virtual read write" $ do
+  let expectedCount = 3
+      -- a simple note-on message
+      message = [0x90, 0x51, 0x7f]
+      portName = "rtmidi-test-port"
+      -- 0.01 second delay in us
+      delayUs = 10000
+  countRef <- newIORef 0
+  -- Create reader with callback
+  inDev <- defaultInput
+  setCallback inDev (readerCallback countRef)
+  openVirtualPort inDev portName
+  -- Create writer and connect to reader virtual port
+  outDev <- defaultOutput
+  maybePortNum <- lookupPort outDev portName
+  let portNum = maybe (error "Could not find port") id maybePortNum
+  openPort outDev portNum portName
+  -- Send messages
+  replicateM_ expectedCount (sendMessage outDev message)
+  -- Sleep a bit to ensure message delivery
+  threadDelay delayUs
+  -- Close writer
+  closePort outDev
+  closeDevice outDev
+  -- Close reader
+  closePort inDev
+  closeDevice inDev
+  -- Verify number of messages received
+  actualCount <- readIORef countRef
+  actualCount @?= expectedCount
+
+main :: IO ()
+main = defaultMain (testGroup "RtMidi" [testVirtualReadWrite])


### PR DESCRIPTION
This PR generalizes the RtMidi interface from `IO` to anything implementing `MonadIO` (and in the callback context, `MonadUnliftIO`). No existing uses need to be changed, because `IO` implements both these classes. This greatly reduces the `liftIO` noise when using these functions from a more complicated transformer stack. For example, you can `allocate` devices in a `ResourceT` stack to have them automatically closed at the end of resource scope. (This is exactly what my forthcoming higher-level library on top of this does!)

(Also includes some small fixes to CircleCI config.)