### PR TITLE
Remove closeDevice with support for finalizers. Also expose setForeignCallback

### DIFF
--- a/RtMidi.cabal
+++ b/RtMidi.cabal
@@ -1,5 +1,5 @@
 name:                RtMidi
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            Haskell wrapper for RtMidi, the lightweight, cross-platform MIDI I/O library.
 description:         Please see the README on GitHub at <https://github.com/riottracker/RtMidi#readme>
 category:            Sound

--- a/Sound/RtMidi/Foreign.hsc
+++ b/Sound/RtMidi/Foreign.hsc
@@ -73,8 +73,8 @@ foreign import ccall "rtmidi_c.h rtmidi_in_create"
 foreign import ccall "rtmidi_c.h rtmidi_in_create_default"
   rtmidi_in_create_default :: IO (Ptr Wrapper)
 
-foreign import ccall "rtmidi_c.h rtmidi_in_free"
-  rtmidi_in_free :: Ptr Wrapper -> IO ()
+foreign import ccall "rtmidi_c.h &rtmidi_in_free"
+  rtmidi_in_free :: FunPtr (Ptr Wrapper -> IO ())
 
 foreign import ccall "rtmidi_c.h rtmidi_in_get_current_api"
   rtmidi_in_get_current_api :: Ptr Wrapper -> IO CInt
@@ -100,8 +100,8 @@ foreign import ccall "rtmidi_c.h rtmidi_out_create"
 foreign import ccall "rtmidi_c.h rtmidi_out_create_default"
   rtmidi_out_create_default :: IO (Ptr Wrapper)
 
-foreign import ccall "rtmidi_c.h rtmidi_out_free"
-  rtmidi_out_free :: Ptr Wrapper -> IO ()
+foreign import ccall "rtmidi_c.h &rtmidi_out_free"
+  rtmidi_out_free :: FunPtr (Ptr Wrapper -> IO ())
 
 foreign import ccall "rtmidi_c.h rtmidi_out_get_current_api"
   rtmidi_out_get_current_api :: Ptr Wrapper -> IO CInt

--- a/examples/callback.hs
+++ b/examples/callback.hs
@@ -1,5 +1,5 @@
 import Data.Word (Word8)
-import Sound.RtMidi (closeDevice, closePort, defaultInput, openPort, setCallback)
+import Sound.RtMidi (closePort, defaultInput, openPort, setCallback)
 import Numeric (showHex)
 
 callback :: Double -> [Word8] -> IO ()
@@ -12,5 +12,4 @@ main = do
   setCallback i callback
   _ <- getLine
   closePort i
-  closeDevice i
   return ()

--- a/examples/playback.hs
+++ b/examples/playback.hs
@@ -1,4 +1,4 @@
-import Sound.RtMidi (closeDevice, closePort, defaultOutput, openPort, sendMessage, portCount, portName)
+import Sound.RtMidi (closePort, defaultOutput, openPort, sendMessage, portCount, portName)
 import Control.Concurrent (threadDelay)
 
 main :: IO ()
@@ -18,4 +18,3 @@ main = do
   mapM_ (\x -> sendMessage device [0x90, x, 0x7f] >> threadDelay 120000) $ take 240 song
   putStrLn "exiting..."
   closePort device
-  closeDevice device

--- a/examples/poll.hs
+++ b/examples/poll.hs
@@ -1,4 +1,4 @@
-import Sound.RtMidi (InputDevice, closeDevice, closePort, defaultInput, getMessage, openPort)
+import Sound.RtMidi (InputDevice, closePort, defaultInput, getMessage, openPort)
 import Control.Concurrent (forkIO, killThread)
 import Control.Monad (forever)
 
@@ -17,5 +17,4 @@ main = do
   _ <- getLine
   killThread id
   closePort i
-  closeDevice i
   return ()

--- a/examples/query.hs
+++ b/examples/query.hs
@@ -1,4 +1,4 @@
-import Sound.RtMidi (closeDevice, compiledApis, createOutput, currentApi, defaultOutput, listPorts)
+import Sound.RtMidi (compiledApis, createOutput, currentApi, defaultOutput, listPorts)
 
 main :: IO ()
 main = do
@@ -9,4 +9,3 @@ main = do
   putStrLn $ "RtMidi output using " ++ (show api)
   putStrLn $ "built-in: " ++ (show builtin)
   putStrLn $ "available ports: " ++ (show portPairs)
-  closeDevice device

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,7 +5,7 @@ import Control.Monad (replicateM_)
 import Data.IORef (IORef, newIORef, readIORef, modifyIORef)
 import Data.List (isInfixOf)
 import Data.Word (Word8)
-import Sound.RtMidi (closeDevice, closePort, defaultInput, defaultOutput, findPort, sendMessage, setCallback, openPort, openVirtualPort)
+import Sound.RtMidi (closePort, defaultInput, defaultOutput, findPort, sendMessage, setCallback, openPort, openVirtualPort)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 
@@ -39,10 +39,8 @@ testVirtualReadWrite = testCase "virtual read write" $ do
   threadDelay delayUs
   -- Close writer
   closePort outDev
-  closeDevice outDev
   -- Close reader
   closePort inDev
-  closeDevice inDev
   -- Verify number of messages received
   actualCount <- readIORef countRef
   actualCount @?= expectedCount


### PR DESCRIPTION
No sense in making folks remember to free memory if Haskell will let us set custom finalizers to free on GC!

Also exposes a low level `setForeignCallback` that lets you set foreign callbacks so you aren't forced to pay the wrapper tax every message if it's not necessary for your application.