### PR TITLE
Fix jack configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "RtMidi"
   cache_ver:
     type: string
-    default: "v1"
+    default: "v3"
 
 commands:
   install_native_deps:
@@ -31,7 +31,7 @@ jobs:
             - stack-<< pipeline.parameters.cache_ver >>-{{ checksum "stack.yaml" }}-{{ checksum "<< pipeline.parameters.project >>.cabal" }}
       - run:
           name: Build project
-          command: stack build --flag RtMidi:jack
+          command: stack build
       - save_cache:
           name: Cache dependencies
           key: stack-<< pipeline.parameters.cache_ver >>-{{ checksum "stack.yaml" }}-{{ checksum "<< pipeline.parameters.project >>.cabal" }}
@@ -56,7 +56,7 @@ jobs:
           command: cabal update
       - run:
           name: Build project
-          command: cabal build -fjack
+          command: cabal build
       - save_cache:
           name: Cache dependencies
           key: cabal-<< pipeline.parameters.cache_ver >>-<< parameters.ghc_ver >>-{{ checksum "<< pipeline.parameters.project >>.cabal" }}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ There is also a `Dockerfile` in the `docker` directory and some `make` targets t
     make docker-repl
 
     # Inside the docker image:
-    cabal update && cabal build -fjack
+    cabal update && cabal build
 
 (Note that you can't use any `RtMidi` functions in the containerized env unless you are running a Linux host, and
 even then you'd probably have to start the process with something like `docker run --device /dev/snd`.)

--- a/RtMidi.cabal
+++ b/RtMidi.cabal
@@ -19,12 +19,12 @@ cabal-version:       >=1.10
 license:             MIT
 
 Flag alsa {
-  Description:  Enable ALSA sequencer api
+  Description:  Enable ALSA sequencer api on Linux
   Default:      True
 }
 
 Flag jack {
-  Description:  Enable JACK api
+  Description:  Enable JACK api on Linux or OSX
   Default:      False
 }
 
@@ -53,7 +53,11 @@ library
       extra-libraries:  jack
 
   if os(darwin)
-    cc-options:       -D__MACOSX_CORE__
+    if flag(jack)
+      cc-options:       -D__MACOSX_CORE__ -D__UNIX_JACK__
+      extra-libraries:  jack
+    else
+      cc-options:       -D__MACOSX_CORE__
     frameworks:       CoreMIDI CoreAudio CoreFoundation
     -- NOTE(ejconlon) This is to make the c ffi wrapper actually catch
     -- the c++ exceptions instead of simply aborting.

--- a/RtMidi.cabal
+++ b/RtMidi.cabal
@@ -28,18 +28,6 @@ Flag jack {
   Default:      False
 }
 
-Flag core {
-  Description:  Enable CoreMIDI api
-  Default:      True
-}
-
--- TODO(ejconlon) Add windows support
--- Flag mm {
---   Description:  Enable Windows Multimedia Library api
---   Default:      False
--- }
-
-
 library
   exposed-modules:     Sound.RtMidi
   other-modules:       Sound.RtMidi.Foreign
@@ -50,13 +38,21 @@ library
   extra-libraries:     stdc++
   c-sources:           rtmidi/RtMidi.cpp
                        rtmidi/rtmidi_c.cpp
-  if flag(alsa) && os(linux)
-    cc-options:       -D__LINUX_ALSA__
-    extra-libraries:  asound pthread
-  if flag(jack) && (os(linux) || os(darwin))
-    cc-options:       -D__UNIX_JACK__
-    extra-libraries:  jack
-  if flag(core) && os(darwin)
+
+  -- TODO(ejconlon) Add windows support
+
+  if os(linux)
+    if flag(alsa) && flag(jack)
+      cc-options:       -D__LINUX_ALSA__ -D__UNIX_JACK__
+      extra-libraries:  asound pthread jack
+    if flag(alsa) && !flag(jack)
+      cc-options:       -D__LINUX_ALSA__
+      extra-libraries:  asound pthread
+    if !flag(alsa) && flag(jack)
+      cc-options:       -D__UNIX_JACK__
+      extra-libraries:  jack
+
+  if os(darwin)
     cc-options:       -D__MACOSX_CORE__
     frameworks:       CoreMIDI CoreAudio CoreFoundation
     -- NOTE(ejconlon) This is to make the c ffi wrapper actually catch
@@ -65,7 +61,6 @@ library
     -- avoid https://gitlab.haskell.org/ghc/ghc/issues/11829
     ld-options:        -Wl,-keep_dwarf_unwind
     ghc-options:       -pgmc=clang++
-  -- TODO(ejconlon) Add windows support
 
 executable rtmidi-callback
   main-is:            callback.hs

--- a/Sound/RtMidi.hs
+++ b/Sound/RtMidi.hs
@@ -138,11 +138,10 @@ ready d = liftIO (withDevicePtr d (fmap ok . peek))
 -- | A static function to determine MIDI 'Api's built in.
 compiledApis :: MonadIO m => m [Api]
 compiledApis = liftIO $ do
-  n <- fmap fromIntegral (rtmidi_get_compiled_api nullPtr)
-  as <- allocaArray n $ flip with $ \ptr -> do
-    rtmidi_get_compiled_api ptr
-    x <- peek ptr
-    peekArray n x
+  n <- fmap fromIntegral (rtmidi_get_compiled_api nullPtr 0)
+  as <- allocaArray n $ \ptr -> do
+    rtmidi_get_compiled_api ptr (fromIntegral n)
+    peekArray n ptr
   pure (map (toEnum . fromIntegral) as)
 
 -- | Open a MIDI connection

--- a/Sound/RtMidi/Foreign.hsc
+++ b/Sound/RtMidi/Foreign.hsc
@@ -28,7 +28,7 @@ module Sound.RtMidi.Foreign
 #include "rtmidi_c.h"
 
 import Foreign (FunPtr, Ptr, Storable (..))
-import Foreign.C (CDouble (..), CInt (..), CString, CSize, CUChar)
+import Foreign.C (CDouble (..), CInt (..), CString, CSize, CUChar, CUInt (..))
 
 data Wrapper = Wrapper
   { ptr :: !(Ptr ())
@@ -52,23 +52,26 @@ instance Storable Wrapper where
     d <- #{peek struct RtMidiWrapper, msg} ptr
     pure (Wrapper a b c d)
 
+-- A parameter we'll be de/serializing from the 'Api' enum.
+type ApiEnum = CInt
+
 foreign import ccall "rtmidi_c.h rtmidi_close_port"
   rtmidi_close_port :: Ptr Wrapper -> IO ()
 
 foreign import ccall "rtmidi_c.h rtmidi_get_compiled_api"
-  rtmidi_get_compiled_api :: Ptr (Ptr CInt) -> IO CInt
+  rtmidi_get_compiled_api :: Ptr ApiEnum -> CUInt -> IO CInt
 
 foreign import ccall "rtmidi_c.h rtmidi_get_port_count"
-  rtmidi_get_port_count :: Ptr Wrapper -> IO CInt
+  rtmidi_get_port_count :: Ptr Wrapper -> IO CUInt
 
 foreign import ccall "rtmidi_c.h rtmidi_get_port_name"
-  rtmidi_get_port_name :: Ptr Wrapper -> CInt -> IO CString
+  rtmidi_get_port_name :: Ptr Wrapper -> CUInt -> IO CString
 
 foreign import ccall "rtmidi_c.h rtmidi_in_cancel_callback"
   rtmidi_in_cancel_callback :: Ptr Wrapper -> IO ()
 
 foreign import ccall "rtmidi_c.h rtmidi_in_create"
-  rtmidi_in_create :: CInt -> CString -> CInt -> IO (Ptr Wrapper)
+  rtmidi_in_create :: ApiEnum -> CString -> CUInt -> IO (Ptr Wrapper)
 
 foreign import ccall "rtmidi_c.h rtmidi_in_create_default"
   rtmidi_in_create_default :: IO (Ptr Wrapper)
@@ -77,7 +80,7 @@ foreign import ccall "rtmidi_c.h &rtmidi_in_free"
   rtmidi_in_free :: FunPtr (Ptr Wrapper -> IO ())
 
 foreign import ccall "rtmidi_c.h rtmidi_in_get_current_api"
-  rtmidi_in_get_current_api :: Ptr Wrapper -> IO CInt
+  rtmidi_in_get_current_api :: Ptr Wrapper -> IO ApiEnum
 
 foreign import ccall "rtmidi_c.h rtmidi_in_get_message"
   rtmidi_in_get_message :: Ptr Wrapper -> Ptr (Ptr CUChar) -> Ptr CSize -> IO CDouble
@@ -89,13 +92,13 @@ foreign import ccall "rtmidi_c.h rtmidi_in_set_callback"
   rtmidi_in_set_callback :: Ptr Wrapper -> FunPtr (CDouble -> Ptr CUChar -> CInt -> Ptr () -> IO ()) -> Ptr () -> IO ()
 
 foreign import ccall "rtmidi_c.h rtmidi_open_port"
-  rtmidi_open_port :: Ptr Wrapper -> CInt -> CString -> IO ()
+  rtmidi_open_port :: Ptr Wrapper -> CUInt -> CString -> IO ()
 
 foreign import ccall "rtmidi_c.h rtmidi_open_virtual_port"
   rtmidi_open_virtual_port :: Ptr Wrapper -> CString -> IO ()
 
 foreign import ccall "rtmidi_c.h rtmidi_out_create"
-  rtmidi_out_create :: CInt -> CString -> IO (Ptr Wrapper)
+  rtmidi_out_create :: ApiEnum-> CString -> IO (Ptr Wrapper)
 
 foreign import ccall "rtmidi_c.h rtmidi_out_create_default"
   rtmidi_out_create_default :: IO (Ptr Wrapper)
@@ -104,7 +107,7 @@ foreign import ccall "rtmidi_c.h &rtmidi_out_free"
   rtmidi_out_free :: FunPtr (Ptr Wrapper -> IO ())
 
 foreign import ccall "rtmidi_c.h rtmidi_out_get_current_api"
-  rtmidi_out_get_current_api :: Ptr Wrapper -> IO CInt
+  rtmidi_out_get_current_api :: Ptr Wrapper -> IO ApiEnum
 
 foreign import ccall "rtmidi_c.h rtmidi_out_send_message"
   rtmidi_out_send_message :: Ptr Wrapper -> Ptr CUChar -> CInt -> IO CInt

--- a/docker/packages.txt
+++ b/docker/packages.txt
@@ -1,1 +1,1 @@
-libasound2-dev libjack-dev
+libasound2-dev

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -21,8 +21,8 @@ testVirtualReadWrite api = testCase ("virtual read write with " <> show api) $ d
       -- a simple note-on message
       message = [0x90, 0x51, 0x7f]
       portName = "rtmidi-test-port"
-      -- 0.01 second delay in us
-      delayUs = 10000
+      -- 100 ms delay in us
+      delayUs = 100000
   countRef <- newIORef 0
   -- Create reader with callback
   inDev <- createInput api "rtmidi-test-input" 100


### PR DESCRIPTION
Builds jack in addition to default os-specific backends. Also fix `compiledApis` (which was returning nonsense enum values, mapping them all to `UnspecifiedApi` and test each backend in the unit test. Removes jack from the CI build because we don't run jackd there.