### PR TITLE
Add report functionality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: "RtMidi"
   cache_ver:
     type: string
-    default: "v3"
+    default: "v4"
 
 commands:
   install_native_deps:

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,22 @@ install-dev-deps:
 	# Install some useful packages for development
 	stack build --copy-compiler-tool ghcid hlint stylish-haskell
 
+.PHONY: clean
+clean:
+	stack clean --full
+
+.PHONY: build
+build:
+	stack build --test --no-run-tests
+
+.PHONY: test
+test:
+	stack test
+
+.PHONY: example-report
+example-report: build
+	stack exec -- rtmidi-report
+
 .PHONY: format
 format:
 	# Run stylish-haskell to format our haskell source
@@ -30,16 +46,3 @@ upload-docs:
 	cabal test
 	cabal haddock --haddock-for-hackage --haddock-option=--hyperlinked-source
 	cabal upload  --publish -d dist-newstyle/RtMidi-*-docs.tar.gz
-
-# Dockerized dev targets follow. Yes, this is built into stack, but
-# It's defined here to use for cabal too.
-
-.PHONY: docker-build
-docker-build:
-	# Build a development image for testing builds on linux
-	cd docker && docker build -t haskell-rtmidi-dev .
-
-.PHONY: docker-repl
-docker-repl:
-	# Enter our development image
-	docker run -i -v $(realpath .):/project -w /project -t haskell-rtmidi-dev /bin/bash

--- a/README.md
+++ b/README.md
@@ -17,20 +17,6 @@ You can get started with development like so:
     # Verify that it works:
     stack exec -- rtmidi-query
 
-There is also a `Dockerfile` in the `docker` directory and some `make` targets that can help you verify Linux builds:
-
-    # Build the image and tag it `haskell-rtmidi-dev`
-    make docker-build
-
-    # Enter the docker image
-    make docker-repl
-
-    # Inside the docker image:
-    cabal update && cabal build
-
-(Note that you can't use any `RtMidi` functions in the containerized env unless you are running a Linux host, and
-even then you'd probably have to start the process with something like `docker run --device /dev/snd`.)
-
 ## TODO
 
 * Add Windows MM support. This should only require a few changes to the Cabal file.

--- a/RtMidi.cabal
+++ b/RtMidi.cabal
@@ -1,5 +1,5 @@
 name:                RtMidi
-version:             0.3.0.0
+version:             0.4.0.0
 synopsis:            Haskell wrapper for RtMidi, the lightweight, cross-platform MIDI I/O library.
 description:         Please see the README on GitHub at <https://github.com/riottracker/RtMidi#readme>
 category:            Sound
@@ -30,10 +30,15 @@ Flag jack {
 
 library
   exposed-modules:     Sound.RtMidi
+                     , Sound.RtMidi.Report
   other-modules:       Sound.RtMidi.Foreign
   build-depends:       base >=4.9 && <4.15
+                     , deepseq >= 1.4.4.0 && < 2
                      , unliftio-core >= 0.1.2.0 && < 1
   default-language:    Haskell2010
+  default-extensions:  DeriveGeneric
+                     , DerivingStrategies
+                     , GeneralizedNewtypeDeriving
   include-dirs:        rtmidi
   extra-libraries:     stdc++
   c-sources:           rtmidi/RtMidi.cpp
@@ -99,6 +104,16 @@ executable rtmidi-query
   build-depends:
       base
     , RtMidi
+  default-language:   Haskell2010
+  ghc-options: -threaded -rtsopts
+
+executable rtmidi-report
+  main-is:            report.hs
+  hs-source-dirs:     examples
+  build-depends:
+      base
+    , RtMidi
+    , pretty-simple >= 3.2.3.0 && < 4
   default-language:   Haskell2010
   ghc-options: -threaded -rtsopts
 

--- a/Sound/RtMidi.hs
+++ b/Sound/RtMidi.hs
@@ -8,6 +8,8 @@ module Sound.RtMidi
   , DeviceType (..)
   , Api (..)
   , Error (..)
+  , apiName
+  , apiDisplayName
   , ready
   , compiledApis
   , openPort
@@ -87,7 +89,6 @@ instance IsDevice OutputDevice where
 newOutputDevice :: Ptr Wrapper -> IO OutputDevice
 newOutputDevice = fmap (OutputDevice . Device) . newForeignPtr rtmidi_out_free
 
-
 -- | An internal RtMidi error
 newtype Error = Error { unError :: String }
   deriving stock (Eq, Show, Generic)
@@ -110,6 +111,14 @@ withDevicePtrUnguarded = withForeignPtr . unDevice . toDevice
 -- Operate on the underlying device ptr and guard for errors
 withDevicePtr :: IsDevice d => d -> (Ptr Wrapper -> IO a) -> IO a
 withDevicePtr d f = withDevicePtrUnguarded d (\dptr -> f dptr <* guardError dptr)
+
+-- | Get the display name for the given 'Api'.
+apiDisplayName :: MonadIO m => Api -> m String
+apiDisplayName api = liftIO (rtmidi_api_display_name (fromApi api) >>= peekCString)
+
+-- | Get the internal name for the given 'Api'.
+apiName :: MonadIO m => Api -> m String
+apiName api = liftIO (rtmidi_api_name (fromApi api) >>= peekCString)
 
 -- | Check if a device is ok
 ready :: (MonadIO m, IsDevice d) => d -> m Bool

--- a/Sound/RtMidi.hs
+++ b/Sound/RtMidi.hs
@@ -10,6 +10,7 @@ module Sound.RtMidi
   , Error (..)
   , apiName
   , apiDisplayName
+  , compiledApiByName
   , ready
   , compiledApis
   , openPort
@@ -119,6 +120,10 @@ apiDisplayName api = liftIO (rtmidi_api_display_name (fromApi api) >>= peekCStri
 -- | Get the internal name for the given 'Api'.
 apiName :: MonadIO m => Api -> m String
 apiName api = liftIO (rtmidi_api_name (fromApi api) >>= peekCString)
+
+-- | Lookup a compiled 'Api' by name.
+compiledApiByName :: MonadIO m => String -> m Api
+compiledApiByName name = liftIO (fmap toApi (withCString name rtmidi_compiled_api_by_name))
 
 -- | Check if a device is ok
 ready :: (MonadIO m, IsDevice d) => d -> m Bool

--- a/Sound/RtMidi/Foreign.hsc
+++ b/Sound/RtMidi/Foreign.hsc
@@ -8,6 +8,8 @@ module Sound.RtMidi.Foreign
   , ApiInternal
   , toApi
   , fromApi
+  , rtmidi_api_display_name
+  , rtmidi_api_name
   , rtmidi_close_port
   , rtmidi_get_compiled_api
   , rtmidi_get_port_count
@@ -79,6 +81,12 @@ toApi = toEnum . fromIntegral . unApiInternal
 
 fromApi :: Api -> ApiInternal
 fromApi = ApiInternal . fromIntegral . fromEnum
+
+foreign import ccall "rtmidi_c.h rtmidi_api_display_name"
+  rtmidi_api_display_name :: ApiInternal -> IO CString
+
+foreign import ccall "rtmidi_c.h rtmidi_api_name"
+  rtmidi_api_name :: ApiInternal -> IO CString
 
 foreign import ccall "rtmidi_c.h rtmidi_close_port"
   rtmidi_close_port :: Ptr Wrapper -> IO ()

--- a/Sound/RtMidi/Foreign.hsc
+++ b/Sound/RtMidi/Foreign.hsc
@@ -11,6 +11,7 @@ module Sound.RtMidi.Foreign
   , rtmidi_api_display_name
   , rtmidi_api_name
   , rtmidi_close_port
+  , rtmidi_compiled_api_by_name
   , rtmidi_get_compiled_api
   , rtmidi_get_port_count
   , rtmidi_get_port_name
@@ -68,7 +69,6 @@ data Api
   | AlsaApi
   | JackApi
   | MultimediaApi
-  | KernelStreamingApi
   | DummyApi
   deriving stock (Eq, Show, Ord, Enum, Bounded, Generic)
   deriving anyclass (NFData)
@@ -90,6 +90,9 @@ foreign import ccall "rtmidi_c.h rtmidi_api_name"
 
 foreign import ccall "rtmidi_c.h rtmidi_close_port"
   rtmidi_close_port :: Ptr Wrapper -> IO ()
+
+foreign import ccall "rtmidi_c.h rtmidi_compiled_api_by_name"
+  rtmidi_compiled_api_by_name :: CString -> IO ApiInternal
 
 foreign import ccall "rtmidi_c.h rtmidi_get_compiled_api"
   rtmidi_get_compiled_api :: Ptr ApiInternal -> CUInt -> IO CInt

--- a/Sound/RtMidi/Report.hs
+++ b/Sound/RtMidi/Report.hs
@@ -13,17 +13,21 @@ import Sound.RtMidi
 
 data ApiReport = ApiReport
   { apiRepApi :: !Api
+  , apiRepName :: !String
+  , apiRepDisplayName :: !String
   } deriving stock (Eq, Show, Generic)
     deriving anyclass (NFData)
 
-data Report = Report
-  { apiReports :: ![ApiReport]
+newtype Report = Report
+  { apiReports :: [ApiReport]
   } deriving stock (Eq, Show, Generic)
     deriving anyclass (NFData)
 
 buildApiReport :: MonadIO m => Api -> m ApiReport
 buildApiReport api = do
-  pure (ApiReport api)
+  name <- apiName api
+  displayName <- apiDisplayName api
+  pure (ApiReport api name displayName)
 
 buildReport :: MonadIO m => m Report
 buildReport = do

--- a/Sound/RtMidi/Report.hs
+++ b/Sound/RtMidi/Report.hs
@@ -15,6 +15,8 @@ data ApiReport = ApiReport
   { apiRepApi :: !Api
   , apiRepName :: !String
   , apiRepDisplayName :: !String
+  , apiInPorts :: ![(Int, String)]
+  , apiOutPorts :: ![(Int, String)]
   } deriving stock (Eq, Show, Generic)
     deriving anyclass (NFData)
 
@@ -27,7 +29,11 @@ buildApiReport :: MonadIO m => Api -> m ApiReport
 buildApiReport api = do
   name <- apiName api
   displayName <- apiDisplayName api
-  pure (ApiReport api name displayName)
+  inDev <- createInput api ("rtmidi-report-input-" ++ name) 0
+  inPorts <- listPorts inDev
+  outDev <- createOutput api ("rtmidi-report-output-" ++ name)
+  outPorts <- listPorts outDev
+  pure (ApiReport api name displayName inPorts outPorts)
 
 buildReport :: MonadIO m => m Report
 buildReport = do

--- a/Sound/RtMidi/Report.hs
+++ b/Sound/RtMidi/Report.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE DeriveAnyClass #-}
+
+module Sound.RtMidi.Report
+  ( ApiReport (..)
+  , Report (..)
+  , buildReport
+  ) where
+
+import Control.DeepSeq (NFData)
+import Control.Monad.IO.Class (MonadIO)
+import GHC.Generics (Generic)
+import Sound.RtMidi
+
+data ApiReport = ApiReport
+  { apiRepApi :: !Api
+  } deriving stock (Eq, Show, Generic)
+    deriving anyclass (NFData)
+
+data Report = Report
+  { apiReports :: ![ApiReport]
+  } deriving stock (Eq, Show, Generic)
+    deriving anyclass (NFData)
+
+buildApiReport :: MonadIO m => Api -> m ApiReport
+buildApiReport api = do
+  pure (ApiReport api)
+
+buildReport :: MonadIO m => m Report
+buildReport = do
+  apis <- compiledApis
+  apiReps <- traverse buildApiReport apis
+  pure (Report apiReps)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,0 @@
-FROM haskell:8.8.4
-COPY packages.txt /tmp/packages.txt
-RUN apt-get update && \
-    apt-get install -y $(cat /tmp/packages.txt) && \
-    apt-get clean && \
-    rm /tmp/packages.txt

--- a/examples/report.hs
+++ b/examples/report.hs
@@ -1,0 +1,5 @@
+import Sound.RtMidi.Report (buildReport)
+import Text.Pretty.Simple (pPrint)
+
+main :: IO ()
+main = buildReport >>= pPrint

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.13
+resolver: lts-16.14
 
 packages:
 - .

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,10 +2,11 @@ module Main (main) where
 
 import Control.Concurrent (threadDelay)
 import Control.Monad (replicateM_, unless, when)
+import Data.Foldable (for_)
 import Data.IORef (IORef, newIORef, readIORef, modifyIORef)
 import Data.List (isInfixOf)
 import Data.Word (Word8)
-import Sound.RtMidi (Api (..), closePort, compiledApis, createInput, createOutput, currentApi, findPort, sendMessage, setCallback, openPort, openVirtualPort)
+import Sound.RtMidi (Api (..), apiName, apiDisplayName, closePort, compiledApiByName, compiledApis, createInput, createOutput, currentApi, findPort, sendMessage, setCallback, openPort, openVirtualPort)
 import Sound.RtMidi.Report (Report, buildReport)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
@@ -16,6 +17,35 @@ incIORef = flip modifyIORef succ
 readerCallback :: IORef Int -> Double -> [Word8] -> IO ()
 readerCallback countRef _ msg = incIORef countRef
 
+testApiName :: TestTree
+testApiName = testCase "apiName" $ do
+  actualName1 <- apiName UnspecifiedApi
+  actualName1 @?= "unspecified"
+  actualName2 <- apiName DummyApi
+  actualName2 @?= "dummy"
+
+testApiDisplayName :: TestTree
+testApiDisplayName = testCase "apiDisplayName" $ do
+  actualName1 <- apiDisplayName UnspecifiedApi
+  actualName1 @?= "Unknown"
+  actualName2 <- apiDisplayName DummyApi
+  actualName2 @?= "Dummy"
+
+testCompiledApiByName :: TestTree
+testCompiledApiByName = testCase "compiledApiByName" $ do
+  actualApi1 <- compiledApiByName "unspecified"
+  actualApi1 @?= UnspecifiedApi
+  actualApi2 <- compiledApiByName "dummy"
+  actualApi2 @?= UnspecifiedApi
+  actualApi3 <- compiledApiByName "invalid"
+  actualApi3 @?= UnspecifiedApi
+
+testBuildReport :: TestTree
+testBuildReport = testCase "buildReport" $ do
+  -- We could test more but we mostly just want to make sure we can run 'buildReport'.
+  _ <- buildReport
+  pure ()
+
 testVirtualReadWrite :: Api -> TestTree
 testVirtualReadWrite api = testCase ("virtual read write with " <> show api) $ do
   let expectedCount = 3
@@ -24,6 +54,10 @@ testVirtualReadWrite api = testCase ("virtual read write with " <> show api) $ d
       portName = "rtmidi-test-port"
       -- 100 ms delay in us
       delayUs = 100000
+  -- First a check of api name
+  name <- apiName api
+  actualApi <- compiledApiByName name
+  actualApi @?= api
   countRef <- newIORef 0
   -- Create reader with callback
   inDev <- createInput api "rtmidi-test-input" 100
@@ -50,14 +84,15 @@ testVirtualReadWrite api = testCase ("virtual read write with " <> show api) $ d
   actualCount <- readIORef countRef
   actualCount @?= expectedCount
 
-testReport :: TestTree
-testReport = testCase "report" $ do
-  report <- buildReport
-  pure ()
-
 main :: IO ()
 main = do
   apis <- compiledApis
   let rwTests = fmap testVirtualReadWrite (filter (/= DummyApi) apis)
       rwGroup = testGroup "R/W" rwTests
-  defaultMain (testGroup "RtMidi" [testReport, rwGroup])
+  defaultMain $ testGroup "RtMidi" $
+    [ testApiName
+    , testApiDisplayName
+    , testCompiledApiByName
+    , testBuildReport
+    , rwGroup
+    ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,6 +6,7 @@ import Data.IORef (IORef, newIORef, readIORef, modifyIORef)
 import Data.List (isInfixOf)
 import Data.Word (Word8)
 import Sound.RtMidi (Api (..), closePort, compiledApis, createInput, createOutput, currentApi, findPort, sendMessage, setCallback, openPort, openVirtualPort)
+import Sound.RtMidi.Report (Report, buildReport)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
 
@@ -49,9 +50,14 @@ testVirtualReadWrite api = testCase ("virtual read write with " <> show api) $ d
   actualCount <- readIORef countRef
   actualCount @?= expectedCount
 
+testReport :: TestTree
+testReport = testCase "report" $ do
+  report <- buildReport
+  pure ()
+
 main :: IO ()
 main = do
   apis <- compiledApis
-  when (null apis) (assertFailure "No compiled APIs found")
-  let tests = fmap testVirtualReadWrite apis
-  defaultMain (testGroup "RtMidi" tests)
+  let rwTests = fmap testVirtualReadWrite (filter (/= DummyApi) apis)
+      rwGroup = testGroup "R/W" rwTests
+  defaultMain (testGroup "RtMidi" [testReport, rwGroup])


### PR DESCRIPTION
* Adds `Sound.RtMidi.Report` and an example executable to quickly print all the relevant information about APIs and ports. (This is useful for debugging!)
* Exposes and tests some API name methods.
* Adds a few missing instances to common datatypes, including `NFData`.
* Adds some useful `Makefile` targets and removes not useful ones.